### PR TITLE
Require package immediately

### DIFF
--- a/library/package.json
+++ b/library/package.json
@@ -55,7 +55,6 @@
     "lint-tsc": "tsc --noEmit"
   },
   "dependencies": {
-    "require-in-the-middle": "^7.2.0",
     "shimmer": "^1.2.1"
   }
 }

--- a/library/src/agent/applyHooks.ts
+++ b/library/src/agent/applyHooks.ts
@@ -1,5 +1,4 @@
 import { join } from "node:path";
-import { Hook } from "require-in-the-middle";
 import { wrap } from "shimmer";
 import { getPackageVersion } from "../helpers/getPackageVersion";
 import { satisfiesVersion } from "../helpers/satisfiesVersion";
@@ -82,13 +81,9 @@ function wrapFilesImmediately(pkg: Package, files: WrappableFile[]) {
 }
 
 function wrapWhenModuleIsRequired(pkg: Package, subjects: WrappableSubject[]) {
-  new Hook([pkg.getName()], (exports) => {
-    subjects.forEach((selector) =>
-      wrapSubject(exports, selector, pkg.getName())
-    );
+  const exports = require(pkg.getName());
 
-    return exports;
-  });
+  subjects.forEach((selector) => wrapSubject(exports, selector, pkg.getName()));
 }
 
 function isAikidoGuardBlockError(error: Error) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,6 @@
       "version": "0.0.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
-        "require-in-the-middle": "^7.2.0",
         "shimmer": "^1.2.1"
       },
       "devDependencies": {
@@ -4664,6 +4663,7 @@
       "version": "2.13.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
       "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
+      "dev": true,
       "dependencies": {
         "hasown": "^2.0.0"
       },
@@ -5476,11 +5476,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/module-details-from-path": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.3.tgz",
-      "integrity": "sha512-ySViT69/76t8VhE1xXHK6Ch4NcDd26gx0MzKXLO+F7NOtnqH68d9zF94nT8ZWSxXh8ELOERsnJO/sWt1xZYw5A=="
-    },
     "node_modules/mongodb": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.3.0.tgz",
@@ -6225,7 +6220,8 @@
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
     },
     "node_modules/path-scurry": {
       "version": "1.10.1",
@@ -6803,23 +6799,11 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/require-in-the-middle": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.2.0.tgz",
-      "integrity": "sha512-3TLx5TGyAY6AOqLBoXmHkNql0HIf2RGbuMgCDT2WO/uGVAPJs6h7Kl+bN6TIZGd9bWhWPwnDnTHGtW8Iu77sdw==",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "module-details-from-path": "^1.0.3",
-        "resolve": "^1.22.1"
-      },
-      "engines": {
-        "node": ">=8.6.0"
-      }
-    },
     "node_modules/resolve": {
       "version": "1.22.8",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
       "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+      "dev": true,
       "dependencies": {
         "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
@@ -7677,6 +7661,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },


### PR DESCRIPTION
Require in the middle allows us to hook into the package when the package is actually required, so we don't have to load all the packages at once.

When I was trying the library out in an express based app with `tsx`, I noticed that the express hook wasn't fired (require-in-the-middle's Hook), I think this is because `tsx` modifies the `require` function to transpile TS files on the fly.

To deal with this, we should make sure express is required at all times.

Without request context we can't do anything.

I was first thinking about introducing an option to require the package immediately but having options makes the code less readable and more difficult to understand. Dropping an additional library is also a good thing, then we're down to just one dependency.