### PR TITLE
Add test badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Aikido Guard for Node.js
 
 ![NPM Version](https://img.shields.io/npm/v/%40aikidosec%2Fguard?style=flat-square) ![Codecov](https://img.shields.io/codecov/c/github/AikidoSec/guard-node?style=flat-square&token=AJK9LU35GY) ![NPM License](https://img.shields.io/npm/l/%40aikidosec%2Fguard?style=flat-square)
-[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com) ![](https://github.com/AikidoSec/guard-node/actions/workflows/unit-test.yml/badge.svg) ![](https://github.com/AikidoSec/guard-node/actions/workflows/end-to-end-tests.yml/badge.svg)
 
 ## Features
 


### PR DESCRIPTION
Wanted to use https://shields.io/badges/git-hub-actions-workflow-status

(to have the same style as the others but the repo is still private so)