### PR TITLE
Add keywords for SET syntax

### DIFF
--- a/library/src/vulnerabilities/sql-injection/detectSQLInjection.mysql.test.ts
+++ b/library/src/vulnerabilities/sql-injection/detectSQLInjection.mysql.test.ts
@@ -12,6 +12,75 @@ t.test("It ignores postgres dollar signs", async () => {
   isNotSQLInjection("SELECT $tag$text$tag$", "$tag$text$tag$");
 });
 
+t.test("It flags SET GLOBAL as SQL injection", async () => {
+  isSqlInjection("SET GLOBAL max_connections = 1000", "GLOBAL max_connections");
+  isSqlInjection(
+    "SET @@GLOBAL.max_connections = 1000",
+    "@@GLOBAL.max_connections = 1000"
+  );
+  isSqlInjection(
+    "SET @@GLOBAL.max_connections=1000",
+    "@@GLOBAL.max_connections=1000"
+  );
+
+  isNotSQLInjection(
+    "SELECT * FROM users WHERE id = 'SET GLOBAL max_connections = 1000'",
+    "SET GLOBAL max_connections = 1000"
+  );
+  isNotSQLInjection(
+    "SELECT * FROM users WHERE id = 'SET @@GLOBAL.max_connections = 1000'",
+    "SET @@GLOBAL.max_connections = 1000"
+  );
+});
+
+t.test("It flags SET SESSION as SQL injection", async () => {
+  isSqlInjection(
+    "SET SESSION max_connections = 1000",
+    "SESSION max_connections"
+  );
+  isSqlInjection(
+    "SET @@SESSION.max_connections = 1000",
+    "@@SESSION.max_connections = 1000"
+  );
+  isSqlInjection(
+    "SET @@SESSION.max_connections=1000",
+    "@@SESSION.max_connections=1000"
+  );
+
+  isNotSQLInjection(
+    "SELECT * FROM users WHERE id = 'SET SESSION max_connections = 1000'",
+    "SET SESSION max_connections = 1000"
+  );
+  isNotSQLInjection(
+    "SELECT * FROM users WHERE id = 'SET @@SESSION.max_connections = 1000'",
+    "SET @@SESSION.max_connections = 1000"
+  );
+});
+
+t.test("It flags SET CHARACTER SET as SQL injection", async () => {
+  isSqlInjection("SET CHARACTER SET utf8", "CHARACTER SET utf8");
+  isSqlInjection("SET CHARACTER SET=utf8", "CHARACTER SET=utf8");
+  isSqlInjection("SET CHARSET utf8", "CHARSET utf8");
+  isSqlInjection("SET CHARSET=utf8", "CHARSET=utf8");
+
+  isNotSQLInjection(
+    "SELECT * FROM users WHERE id = 'SET CHARACTER SET utf8'",
+    "SET CHARACTER SET utf8"
+  );
+  isNotSQLInjection(
+    "SELECT * FROM users WHERE id = 'SET CHARACTER SET=utf8'",
+    "SET CHARACTER SET=utf8"
+  );
+  isNotSQLInjection(
+    "SELECT * FROM users WHERE id = 'SET CHARSET utf8'",
+    "SET CHARSET utf8"
+  );
+  isNotSQLInjection(
+    "SELECT * FROM users WHERE id = 'SET CHARSET=utf8'",
+    "SET CHARSET=utf8"
+  );
+});
+
 function isSqlInjection(sql: string, input: string) {
   t.same(detectSQLInjection(sql, input, new SQLDialectMySQL()), true, sql);
 }

--- a/library/src/vulnerabilities/sql-injection/detectSQLInjection.postgres.test.ts
+++ b/library/src/vulnerabilities/sql-injection/detectSQLInjection.postgres.test.ts
@@ -18,6 +18,21 @@ t.test("It flags double dollar sign as SQL injection", async () => {
   isNotSQLInjection("SELECT '$$text$$'", "$$text$$");
 });
 
+t.test("It flags CLIENT_ENCODING as SQL injection", async () => {
+  isSqlInjection("SET CLIENT_ENCODING TO 'UTF8'", "CLIENT_ENCODING TO 'UTF8'");
+  isSqlInjection("SET CLIENT_ENCODING = 'UTF8'", "CLIENT_ENCODING = 'UTF8'");
+  isSqlInjection("SET CLIENT_ENCODING='UTF8'", "CLIENT_ENCODING='UTF8'");
+
+  isNotSQLInjection(
+    `SELECT * FROM users WHERE id = 'SET CLIENT_ENCODING = "UTF8"'`,
+    `SET CLIENT_ENCODING = "UTF8"`
+  );
+  isNotSQLInjection(
+    `SELECT * FROM users WHERE id = 'SET CLIENT_ENCODING TO "UTF8"'`,
+    `SET CLIENT_ENCODING TO "UTF8"`
+  );
+});
+
 function isSqlInjection(sql: string, input: string) {
   t.same(detectSQLInjection(sql, input, new SQLDialectPostgres()), true, sql);
 }

--- a/library/src/vulnerabilities/sql-injection/dialects/SQLDialect.ts
+++ b/library/src/vulnerabilities/sql-injection/dialects/SQLDialect.ts
@@ -1,4 +1,9 @@
 export interface SQLDialect {
-  // Use this to add keywords that are specific to the SQL dialect
+  // Use this to add dangerous strings that are specific to the SQL dialect
+  // These are matched without surrounding spaces, so if you add "SELECT" it will match "SELECT" and "SELECTED"
   getDangerousStrings(): string[];
+
+  // Use this to add keywords that are specific to the SQL dialect
+  // These are matched with surrounding spaces, so if you add "SELECT" it will match "SELECT" but not "SELECTED"
+  getKeywords(): string[];
 }

--- a/library/src/vulnerabilities/sql-injection/dialects/SQLDialectMySQL.ts
+++ b/library/src/vulnerabilities/sql-injection/dialects/SQLDialectMySQL.ts
@@ -5,4 +5,20 @@ export class SQLDialectMySQL implements SQLDialect {
   getDangerousStrings(): string[] {
     return [];
   }
+
+  getKeywords(): string[] {
+    return [
+      // https://dev.mysql.com/doc/refman/8.0/en/set-variable.html
+      "GLOBAL",
+      "SESSION",
+      "PERSIST",
+      "PERSIST_ONLY",
+      "@@GLOBAL",
+      "@@SESSION",
+
+      // https://dev.mysql.com/doc/refman/8.0/en/set-character-set.html
+      "CHARACTER SET",
+      "CHARSET",
+    ];
+  }
 }

--- a/library/src/vulnerabilities/sql-injection/dialects/SQLDialectPostgres.ts
+++ b/library/src/vulnerabilities/sql-injection/dialects/SQLDialectPostgres.ts
@@ -3,7 +3,16 @@ import { SQLDialect } from "./SQLDialect";
 
 export class SQLDialectPostgres implements SQLDialect {
   getDangerousStrings(): string[] {
-    // https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-DOLLAR-QUOTING
-    return ["$"];
+    return [
+      // https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-DOLLAR-QUOTING
+      "$",
+    ];
+  }
+
+  getKeywords(): string[] {
+    return [
+      // https://www.postgresql.org/docs/current/sql-set.html
+      "CLIENT_ENCODING",
+    ];
   }
 }

--- a/library/src/vulnerabilities/sql-injection/userInputContainsSQLSyntax.ts
+++ b/library/src/vulnerabilities/sql-injection/userInputContainsSQLSyntax.ts
@@ -26,7 +26,9 @@ export function userInputContainsSQLSyntax(
 function buildRegex(dialect: SQLDialect) {
   const matchSqlKeywords =
     "(?<![a-z])(" + // Lookbehind : if the keywords are preceded by one or more letters, it should not match
-    SQL_KEYWORDS.map(escapeStringRegexp).join("|") + // Look for SQL Keywords
+    SQL_KEYWORDS.concat(dialect.getKeywords())
+      .map(escapeStringRegexp)
+      .join("|") + // Look for SQL Keywords
     ")(?![a-z])"; // Lookahead : if the keywords are followed by one or more letters, it should not match
 
   const matchSqlOperators = `(${SQL_OPERATORS.map(escapeStringRegexp).join("|")})`;


### PR DESCRIPTION
This syntax:

SET CHARACTER SET=utf8

Gets flagged because of the `=` operator inside.

Keywords are matched with space arround them, keep in mind.