### PR TITLE
Fix typo, it's export instead of exports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,11 +28,11 @@ express-mariadb:
 
 .PHONY: lambda-mongodb-nosql-injection
 lambda-mongodb-nosql-injection:
-	cd sample-apps/lambda-mongodb && npx serverless invoke local --function login --path payloads/nosql-injection-request.json
+	cd sample-apps/lambda-mongodb && npx serverless invoke local -e AIKIDO_BLOCKING=true --function login --path payloads/nosql-injection-request.json
 
 .PHONY: lambda-mongodb-safe
 lambda-mongodb-safe:
-	cd sample-apps/lambda-mongodb && npx serverless invoke local --function login --path payloads/safe-request.json
+	cd sample-apps/lambda-mongodb && npx serverless invoke local -e AIKIDO_BLOCKING=true --function login --path payloads/safe-request.json
 
 .PHONY: install
 install:

--- a/end2end/tests/lambda-mongodb.test.js
+++ b/end2end/tests/lambda-mongodb.test.js
@@ -1,0 +1,64 @@
+const t = require("tap");
+const { resolve } = require("path");
+const { promisify } = require("util");
+const { exec } = require("child_process");
+const execAsync = promisify(exec);
+
+const directory = resolve(__dirname, "../../sample-apps/lambda-mongodb");
+
+t.test("it does not block by default", async (t) => {
+  const { stdout, stderr } = await execAsync(
+    "npx serverless invoke local --function login --path payloads/nosql-injection-request.json",
+    {
+      cwd: directory,
+    }
+  );
+
+  t.same(stderr, "");
+  t.same(JSON.parse(stdout.toString()), {
+    statusCode: 200,
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: {
+      token: "123",
+      success: true,
+    },
+  });
+});
+
+t.test("it blocks when AIKIDO_BLOCKING is true", async (t) => {
+  const { stdout, stderr } = await execAsync(
+    "npx serverless invoke local -e AIKIDO_BLOCKING=true --function login --path payloads/nosql-injection-request.json",
+    {
+      cwd: directory,
+    }
+  );
+
+  t.same(stdout, "");
+  t.match(stderr, /Aikido runtime has blocked a NoSQL injection/);
+});
+
+t.test(
+  "it does not block safe requests when AIKIDO_BLOCKING is true",
+  async (t) => {
+    const { stdout, stderr } = await execAsync(
+      "npx serverless invoke local -e AIKIDO_BLOCKING=true --function login --path payloads/safe-request.json",
+      {
+        cwd: directory,
+      }
+    );
+
+    t.same(stderr, "");
+    t.same(JSON.parse(stdout.toString()), {
+      statusCode: 200,
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: {
+        token: "123",
+        success: true,
+      },
+    });
+  }
+);

--- a/library/src/exports/cloud-function.ts
+++ b/library/src/exports/cloud-function.ts
@@ -1,3 +1,3 @@
 import { cloudFunction } from "../agent/protect";
 
-exports = cloudFunction();
+export = cloudFunction();

--- a/library/src/exports/lambda.ts
+++ b/library/src/exports/lambda.ts
@@ -1,3 +1,3 @@
 import { lambda } from "../agent/protect";
 
-exports = lambda();
+export = lambda();


### PR DESCRIPTION
Let's add an end2end test to catch this mistake.