### PR TITLE
Hide npm warnings

### DIFF
--- a/end2end/tests/lambda-mongodb.test.js
+++ b/end2end/tests/lambda-mongodb.test.js
@@ -6,6 +6,9 @@ const execAsync = promisify(exec);
 
 const directory = resolve(__dirname, "../../sample-apps/lambda-mongodb");
 
+// Invoking serverless functions can be slow
+t.setTimeout(60000);
+
 // Ensure the serverless CLI is installed
 t.before(async () => {
   await execAsync("npx --loglevel=error serverless --help", {


### PR DESCRIPTION
(When serverless package is installed)

We expect an empty string for stdout