### PR TITLE
Fix context sometimes not available in event handlers

### DIFF
--- a/end2end/tests/express-postgres.test.js
+++ b/end2end/tests/express-postgres.test.js
@@ -45,11 +45,15 @@ t.test("it blocks in blocking mode", (t) => {
         fetch("http://localhost:4000/?petname=Njuska", {
           signal: AbortSignal.timeout(5000),
         }),
+        fetch("http://localhost:4000/context-test", {
+          signal: AbortSignal.timeout(5000),
+        }),
       ]);
     })
-    .then(([noSQLInjection, normalSearch]) => {
+    .then(([noSQLInjection, normalSearch, contextTest]) => {
       t.equal(noSQLInjection.status, 500);
       t.equal(normalSearch.status, 200);
+      t.equal(contextTest.status, 200);
       t.match(stdout, /Starting agent/);
       t.match(stderr, /Aikido firewall has blocked an SQL injection/);
     })

--- a/library/agent/Context.test.ts
+++ b/library/agent/Context.test.ts
@@ -1,0 +1,51 @@
+import * as t from "tap";
+import { type Context, getContext, runWithContext } from "./Context";
+
+const sampleContext: Context = {
+  remoteAddress: "::1",
+  method: "POST",
+  url: "http://localhost:4000",
+  query: {},
+  headers: {},
+  body: undefined,
+  cookies: {},
+  routeParams: {},
+  source: "express",
+  route: "/posts/:id",
+};
+
+t.test("context is passed to the function", async (t) => {
+  runWithContext(sampleContext, () => {
+    t.match(getContext(), sampleContext);
+  });
+});
+
+t.test("context is not shared outside of runWithContext", async (t) => {
+  runWithContext(sampleContext, () => {
+    t.match(getContext(), sampleContext);
+  });
+
+  t.equal(getContext(), undefined);
+});
+
+t.test("context is modified properly when already set", async (t) => {
+  runWithContext({ ...sampleContext, method: "GET" }, () => {
+    const context = getContext();
+    if (!context) {
+      t.fail();
+      return;
+    }
+    runWithContext(context, () => {
+      t.match(getContext(), { ...sampleContext, method: "GET" });
+    });
+  });
+});
+
+t.test("context is available in callback functions", (t) => {
+  runWithContext(sampleContext, () => {
+    setTimeout(() => {
+      t.match(getContext(), sampleContext);
+      t.end();
+    }, 10);
+  });
+});

--- a/library/agent/Context.ts
+++ b/library/agent/Context.ts
@@ -1,5 +1,6 @@
 import type { ParsedQs } from "qs";
 import { ContextStorage } from "./context/ContextStorage";
+import { AsyncLocalStorage } from "async_hooks";
 
 export type User = { id: string; name?: string };
 
@@ -62,4 +63,12 @@ export function runWithContext<T>(context: Context, fn: () => T) {
 
   // If there's no context yet, we create a new context and run the function with it
   return ContextStorage.run(context, fn);
+}
+
+/**
+ * Binds the AsyncLocalStorage to a function
+ * This fixes the issue that context is not available in event handlers that are called outside of runWithContext
+ */
+export function bindContext<T>(fn: () => T) {
+  return AsyncLocalStorage.bind(fn);
 }

--- a/library/agent/Context.ts
+++ b/library/agent/Context.ts
@@ -1,6 +1,6 @@
 import type { ParsedQs } from "qs";
 import { ContextStorage } from "./context/ContextStorage";
-import { AsyncLocalStorage } from "async_hooks";
+import { AsyncResource } from "async_hooks";
 
 export type User = { id: string; name?: string };
 
@@ -66,9 +66,10 @@ export function runWithContext<T>(context: Context, fn: () => T) {
 }
 
 /**
- * Binds the AsyncLocalStorage to a function
+ * Binds the given function to the current execution context.
  * This fixes the issue that context is not available in event handlers that are called outside of runWithContext
+ * Static method AsyncLocalStorage.bind(fn) was added in Node.js v19.8.0 and v18.16.0, so we can't use it yet
  */
 export function bindContext<T>(fn: () => T) {
-  return AsyncLocalStorage.bind(fn);
+  return AsyncResource.bind(fn);
 }

--- a/library/agent/applyHooks.ts
+++ b/library/agent/applyHooks.ts
@@ -6,7 +6,7 @@ import { getPackageVersion } from "../helpers/getPackageVersion";
 import { satisfiesVersion } from "../helpers/satisfiesVersion";
 import { Agent } from "./Agent";
 import { attackKindHumanName } from "./Attack";
-import { getContext } from "./Context";
+import { bindContext, getContext } from "./Context";
 import { BuiltinModule } from "./hooks/BuiltinModule";
 import { ConstructorInterceptor } from "./hooks/ConstructorInterceptor";
 import { Hooks } from "./hooks/Hooks";
@@ -19,7 +19,6 @@ import { Package } from "./hooks/Package";
 import { WrappableFile } from "./hooks/WrappableFile";
 import { WrappableSubject } from "./hooks/WrappableSubject";
 import { MethodResultInterceptor } from "./hooks/MethodResultInterceptor";
-import { AsyncLocalStorage } from "async_hooks";
 
 /**
  * Hooks allows you to register packages and then wrap specific methods on
@@ -162,7 +161,7 @@ function wrapWithoutArgumentModification(
 
         for (let i = 0; i < args.length; i++) {
           if (typeof args[i] === "function") {
-            args[i] = AsyncLocalStorage.bind(args[i]);
+            args[i] = bindContext(args[i]);
           }
         }
 
@@ -268,12 +267,6 @@ function wrapWithArgumentModification(
             method: method.getName(),
             module: module,
           });
-        }
-
-        for (let i = 0; i < updatedArgs.length; i++) {
-          if (typeof updatedArgs[i] === "function") {
-            updatedArgs[i] = AsyncLocalStorage.bind(updatedArgs[i]);
-          }
         }
 
         return original.apply(

--- a/library/sinks/MySQL.test.ts
+++ b/library/sinks/MySQL.test.ts
@@ -1,7 +1,7 @@
 import * as t from "tap";
 import { Agent } from "../agent/Agent";
 import { ReportingAPIForTesting } from "../agent/api/ReportingAPIForTesting";
-import { runWithContext, type Context } from "../agent/Context";
+import { getContext, runWithContext, type Context } from "../agent/Context";
 import { LoggerNoop } from "../agent/logger/LoggerNoop";
 import { MySQL } from "./MySQL";
 import type { Connection } from "mysql";
@@ -149,6 +149,12 @@ t.test("it detects SQL injections", async () => {
         return connection.query("-- This is a comment");
       }
     );
+
+    runWithContext(context, () => {
+      connection.query("SELECT petname FROM `cats`;", (error, results) => {
+        t.same(getContext(), context);
+      });
+    });
   } catch (error: any) {
     t.fail(error);
   } finally {

--- a/library/sinks/Postgres.test.ts
+++ b/library/sinks/Postgres.test.ts
@@ -1,7 +1,7 @@
 import * as t from "tap";
 import { Agent } from "../agent/Agent";
 import { ReportingAPIForTesting } from "../agent/api/ReportingAPIForTesting";
-import { runWithContext, type Context } from "../agent/Context";
+import { getContext, runWithContext, type Context } from "../agent/Context";
 import { LoggerNoop } from "../agent/logger/LoggerNoop";
 import { Postgres } from "./Postgres";
 
@@ -20,7 +20,7 @@ const context: Context = {
   route: "/posts/:id",
 };
 
-t.test("it inspects query method calls and blocks if needed", async () => {
+t.test("it inspects query method calls and blocks if needed", async (t) => {
   const agent = new Agent(
     true,
     new LoggerNoop(),
@@ -123,6 +123,13 @@ t.test("it inspects query method calls and blocks if needed", async () => {
         return client.query("-- This is a comment");
       }
     );
+
+    // Check if context is available in the callback
+    runWithContext(context, () => {
+      client.query("SELECT petname FROM cats;", (error, result) => {
+        t.match(getContext(), context);
+      });
+    });
   } catch (error: any) {
     t.fail(error);
   } finally {

--- a/sample-apps/express-postgres/app.js
+++ b/sample-apps/express-postgres/app.js
@@ -72,16 +72,27 @@ async function main(port) {
           return;
         }
 
-        // End2end test check
-        if (!getContext()) {
-          res.status(500).send("Error: Aikido firewall context not found");
-          return;
-        }
-
         res.redirect("/");
       });
     })
   );
+
+  app.get("/context-test", (req, res) => {
+    db.query("SELECT * FROM cats;", function afterSelect(err) {
+      if (err) {
+        res.status(500).send("Error selecting from table");
+        return;
+      }
+
+      // End2end test check
+      if (!getContext()) {
+        res.status(500).send("Error: Aikido firewall context not found");
+        return;
+      }
+
+      res.send("Context found");
+    });
+  });
 
   return new Promise((resolve, reject) => {
     try {


### PR DESCRIPTION
Our context was not available inside callbacks, that are called by an event emitter from outside of runWithContext.

```ts
    const { EventEmitter } = require("events");
    const emitter = new EventEmitter();

    await runWithContext(sampleContext, async () => {
      emitter.on("event", () => {
        // getContext() returned undefined here
      });
    });

    emitter.emit("event");
```

This also affects e.g. `pg` and `mysql` and leads to the problem that we do not detect any injection inside nested database queries (using callbacks).