### PR TITLE
Check if built in module is available

### DIFF
--- a/library/agent/applyHooks.ts
+++ b/library/agent/applyHooks.ts
@@ -20,6 +20,7 @@ import { Package } from "./hooks/Package";
 import { WrappableFile } from "./hooks/WrappableFile";
 import { WrappableSubject } from "./hooks/WrappableSubject";
 import { MethodResultInterceptor } from "./hooks/MethodResultInterceptor";
+import { isPackageInstalled } from "../helpers/isPackageInstalled";
 
 /**
  * Hooks allows you to register packages and then wrap specific methods on
@@ -125,6 +126,9 @@ function wrapBuiltInModule(
   subjects: WrappableSubject[],
   agent: Agent
 ) {
+  if (!isPackageInstalled(module.getName())) {
+    return;
+  }
   const exports = require(module.getName());
 
   subjects.forEach(

--- a/library/sinks/NodeSqlite.ts
+++ b/library/sinks/NodeSqlite.ts
@@ -2,7 +2,6 @@ import { getContext } from "../agent/Context";
 import { Hooks } from "../agent/hooks/Hooks";
 import { InterceptorResult } from "../agent/hooks/MethodInterceptor";
 import { Wrapper } from "../agent/Wrapper";
-import { isPackageInstalled } from "../helpers/isPackageInstalled";
 import { checkContextForSqlInjection } from "../vulnerabilities/sql-injection/checkContextForSqlInjection";
 import type { SQLDialect } from "../vulnerabilities/sql-injection/dialects/SQLDialect";
 import { SQLDialectSQLite } from "../vulnerabilities/sql-injection/dialects/SQLDialectSQLite";
@@ -11,10 +10,6 @@ export class NodeSQLite implements Wrapper {
   private readonly dialect: SQLDialect = new SQLDialectSQLite();
 
   wrap(hooks: Hooks) {
-    if (!isPackageInstalled("node:sqlite")) {
-      return;
-    }
-
     const database = hooks
       .addBuiltinModule("node:sqlite")
       .addSubject((exports) => {


### PR DESCRIPTION
Prevent wrapping an internal Node.js module that is not available in a specific node version or without an experimental flag.