### PR TITLE
Convert arrays to plain strings in Context

### DIFF
--- a/library/helpers/extractStringsFromUserInput.test.ts
+++ b/library/helpers/extractStringsFromUserInput.test.ts
@@ -33,6 +33,7 @@ t.test("it can extract query objects", async () => {
       age: ".",
       whaat: ".user_input.[0]",
       dangerous: ".user_input.[1]",
+      "whaat,dangerous": ".user_input",
     })
   );
 });
@@ -148,6 +149,46 @@ t.test("it also adds the JWT itself as string", async () => {
     fromObj({
       header: ".",
       "/;ping%20localhost;.e30=.": ".header",
+    })
+  );
+});
+
+t.test("it concatenates array values", async () => {
+  t.same(
+    extractStringsFromUserInput({ arr: ["1", "2", "3"] }),
+    fromObj({
+      arr: ".",
+      "1,2,3": ".arr",
+      "1": ".arr.[0]",
+      "2": ".arr.[1]",
+      "3": ".arr.[2]",
+    })
+  );
+
+  t.same(
+    extractStringsFromUserInput({
+      arr: ["1", 2, true, null, undefined, { test: "test" }],
+    }),
+    fromObj({
+      arr: ".",
+      "1": ".arr.[0]",
+      test: ".arr.[5].test",
+      "1,2,true,,,[object Object]": ".arr",
+    })
+  );
+
+  t.same(
+    extractStringsFromUserInput({
+      arr: ["1", 2, true, null, undefined, { test: ["test123", "test345"] }],
+    }),
+    fromObj({
+      arr: ".",
+      "1": ".arr.[0]",
+      test: ".arr.[5]",
+      test123: ".arr.[5].test.[0]",
+      test345: ".arr.[5].test.[1]",
+      "test123,test345": ".arr.[5].test",
+      "1,2,true,,,[object Object]": ".arr",
     })
   );
 });

--- a/library/helpers/extractStringsFromUserInput.ts
+++ b/library/helpers/extractStringsFromUserInput.ts
@@ -31,6 +31,8 @@ export function extractStringsFromUserInput(
         pathToPayload.concat([{ type: "array", index: i }])
       ).forEach((value, key) => results.set(key, value));
     }
+    // Add array as string to results
+    results.set(obj.join(), buildPathToPayload(pathToPayload));
   }
 
   if (typeof obj == "string") {


### PR DESCRIPTION
This fixes
- Bypass using HTTP Parameter pollution
- Bypass by unexpected arrays in JSON without sufficient validation of user input

```js
db.exec(`INSERT INTO cats_2 (petname, comment) VALUES ('${req.query.petname}');`)
```
If req.query.petname is an array, it will be automatically converted into a comma separated string. This can for example be used to insert multiple rows into the db by `?petname='&petname=1)&petname=(2`.