### PR TITLE
Wrap IPv6 with square brackets so that we can construct URL

### DIFF
--- a/library/sinks/HTTPRequest.axios.test.ts
+++ b/library/sinks/HTTPRequest.axios.test.ts
@@ -67,4 +67,24 @@ t.test("it works", async (t) => {
       "Aikido firewall has blocked a server-side request forgery: http.request(...) originating from body.image"
     );
   }
+
+  const error2 = await t.rejects(
+    runWithContext(
+      {
+        ...context,
+        ...{ body: { image: "http://vuln.atwebpages.com" } },
+      },
+      async () => {
+        await axios.request("http://vuln.atwebpages.com");
+      }
+    )
+  );
+
+  t.ok(error2 instanceof Error);
+  if (error2 instanceof Error) {
+    t.match(
+      error2.message,
+      "Aikido firewall has blocked a server-side request forgery: http.request(...) originating from body.image"
+    );
+  }
 });

--- a/library/sinks/HTTPRequest.followRedirects.test.ts
+++ b/library/sinks/HTTPRequest.followRedirects.test.ts
@@ -81,6 +81,26 @@ t.test("it works", (t) => {
     }
   );
 
+  runWithContext(
+    {
+      ...context,
+      ...{ body: { image: "http://vuln.atwebpages.com" } },
+    },
+    () => {
+      const response = http.request("http://vuln.atwebpages.com", (res) => {
+        t.fail("should not respond");
+      });
+      response.on("error", (e) => {
+        t.ok(e instanceof Error);
+        t.same(
+          e.message,
+          "Redirected request failed: Aikido firewall has blocked a server-side request forgery: http.request(...) originating from body.image"
+        );
+      });
+      response.end();
+    }
+  );
+
   setTimeout(() => {
     t.end();
   }, 3000);

--- a/library/sinks/http-request/getUrlFromHTTPRequestArgs.test.ts
+++ b/library/sinks/http-request/getUrlFromHTTPRequestArgs.test.ts
@@ -52,9 +52,19 @@ t.test("it works with options", async (t) => {
   );
 });
 
+t.test("it wraps host and hostname with square brackets", async (t) => {
+  t.same(
+    getURL([{ protocol: "http:", host: "::", port: 80 }], "http"),
+    new URL("http://[::]:80")
+  );
+  t.same(
+    getURL([{ protocol: "http:", hostname: "::", port: 80 }], "http"),
+    new URL("http://[::]:80")
+  );
+});
+
 t.test("it does not throw on invalid arguments", async (t) => {
   t.same(getURL([], "http"), undefined);
-  // @ts-expect-error Testing invalid arguments
   t.same(getURL(["%test%"], undefined), undefined);
   t.same(new Date(), []);
 });

--- a/library/sinks/http-request/getUrlFromHTTPRequestArgs.ts
+++ b/library/sinks/http-request/getUrlFromHTTPRequestArgs.ts
@@ -1,5 +1,6 @@
 import type { RequestOptions as HTTPSRequestOptions } from "https";
 import type { RequestOptions as HTTPRequestOptions } from "http";
+import { isIPv6 } from "net";
 import { tryParseURL } from "../../helpers/tryParseURL";
 import { isOptionsObject } from "./isOptionsObject";
 
@@ -68,11 +69,12 @@ function getUrlFromRequestOptions(
   } else if (module) {
     str += `${module}:`;
   }
+
   str += "//";
   if (typeof options.hostname === "string") {
-    str += options.hostname;
+    str += wrapWithSquareBracketsIfNeeded(options.hostname);
   } else if (typeof options.host === "string") {
-    str += options.host;
+    str += wrapWithSquareBracketsIfNeeded(options.host);
   }
 
   if (options.port) {
@@ -87,7 +89,16 @@ function getUrlFromRequestOptions(
   if (typeof options.path === "string") {
     str += options.path;
   }
+
   return tryParseURL(str);
+}
+
+function wrapWithSquareBracketsIfNeeded(hostname: string): string {
+  if (isIPv6(hostname)) {
+    return `[${hostname}]`;
+  }
+
+  return hostname;
 }
 
 /**


### PR DESCRIPTION
given an URL like

http://[::]:80

axios and follow redirects will pass `::` as hostname to http(s).request

we try to construct an URL object from these separate arguments (protocol, hostname, port, path, ...) but this fails because we end up with the following URL:

http://:::80

so we need to wrap it again with square brackets if it's an IPv6 address