### PR TITLE
Enable firewall only if env vars are set

### DIFF
--- a/library/agent/protect.ts
+++ b/library/agent/protect.ts
@@ -40,21 +40,8 @@ import { Hapi } from "../sources/Hapi";
 import { Shelljs } from "../sinks/Shelljs";
 import { NodeSQLite } from "../sinks/NodeSqlite";
 import { BetterSQLite3 } from "../sinks/BetterSQLite3";
-
-function isDebugging() {
-  return (
-    process.env.AIKIDO_DEBUG === "true" || process.env.AIKIDO_DEBUG === "1"
-  );
-}
-
-function shouldBlock() {
-  return (
-    process.env.AIKIDO_BLOCKING === "true" ||
-    process.env.AIKIDO_BLOCKING === "1" ||
-    process.env.AIKIDO_BLOCK === "true" ||
-    process.env.AIKIDO_BLOCK === "1"
-  );
-}
+import { isDebugging } from "../helpers/isDebugging";
+import { shouldBlock } from "../helpers/shouldBlock";
 
 function getLogger(): Logger {
   if (isDebugging()) {

--- a/library/helpers/isDebugging.ts
+++ b/library/helpers/isDebugging.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks if AIKIDO_DEBUG is set to true or 1
+ */
+export function isDebugging() {
+  return (
+    process.env.AIKIDO_DEBUG === "true" || process.env.AIKIDO_DEBUG === "1"
+  );
+}

--- a/library/helpers/shouldBlock.ts
+++ b/library/helpers/shouldBlock.ts
@@ -1,0 +1,13 @@
+/**
+ * Check the environment variables to see if the firewall should block requests if an attack is detected.
+ * - AIKIDO_BLOCKING=true or AIKIDO_BLOCKING=1
+ * - AIKIDO_BLOCK=true or AIKIDO_BLOCK=1
+ */
+export function shouldBlock() {
+  return (
+    process.env.AIKIDO_BLOCKING === "true" ||
+    process.env.AIKIDO_BLOCKING === "1" ||
+    process.env.AIKIDO_BLOCK === "true" ||
+    process.env.AIKIDO_BLOCK === "1"
+  );
+}

--- a/library/helpers/shouldEnableFirewall.ts
+++ b/library/helpers/shouldEnableFirewall.ts
@@ -1,0 +1,29 @@
+import { isDebugging } from "./isDebugging";
+import { shouldBlock } from "./shouldBlock";
+
+/**
+ * Only enable firewall if at least one of the following environment variables is set to a valid value:
+ * - AIKIDO_BLOCKING
+ * - AIKIDO_BLOCK
+ * - AIKIDO_TOKEN
+ * - AIKIDO_DEBUG
+ */
+export default function shouldEnableFirewall() {
+  if (shouldBlock()) {
+    return true;
+  }
+
+  if (process.env.AIKIDO_TOKEN) {
+    return true;
+  }
+
+  if (isDebugging()) {
+    return true;
+  }
+
+  // eslint-disable-next-line no-console
+  console.log(
+    "AIKIDO: Firewall is disabled. Configure one of the following environment variables to enable it: AIKIDO_BLOCK, AIKIDO_TOKEN, AIKIDO_DEBUG."
+  );
+  return false;
+}

--- a/library/index.ts
+++ b/library/index.ts
@@ -1,7 +1,9 @@
 import isFirewallSupported from "./helpers/isFirewallSupported";
+import shouldEnableFirewall from "./helpers/shouldEnableFirewall";
 
 const supported = isFirewallSupported();
+const shouldEnable = shouldEnableFirewall();
 
-if (supported) {
+if (supported && shouldEnable) {
   require("./agent/protect").protect();
 }


### PR DESCRIPTION
If none of the following environment variables are defined, the firewall returns as soon as possible and no longer changes any imported packets.

- AIKIDO_BLOCKING
- AIKIDO_BLOCK
- AIKIDO_TOKEN
- AIKIDO_DEBUG