### PR TITLE
Only sample first 20 requests for api discovery

### DIFF
--- a/benchmarks/api-discovery/benchmark.js
+++ b/benchmarks/api-discovery/benchmark.js
@@ -19,11 +19,11 @@ function main() {
   const avgTime = getAvgBenchmark();
   if (avgTime > MAX_TIME_LIMIT) {
     console.error(
-      `Average time it took for cre : ${avgTime}ms, this exceeds the allowed time of ${MAX_TIME_LIMIT}ms!`
+      `Average time it took for analyzing api route: ${avgTime}ms, this exceeds the allowed time of ${MAX_TIME_LIMIT}ms!`
     );
     process.exit(1);
   }
-  console.info(`Average time it took for analyzing api route : ${avgTime}ms`);
+  console.info(`Average time it took for analyzing api route: ${avgTime}ms`);
   process.exit(0);
 }
 

--- a/benchmarks/api-discovery/reqBodies.js
+++ b/benchmarks/api-discovery/reqBodies.js
@@ -181,4 +181,42 @@ module.exports = [
       },
     ],
   },
+  {
+    user: {
+      id: 5,
+      name: "Jane Doe",
+      email: "jane.doe@example.com",
+      address: {
+        street: "123 Main St",
+        city: "New York",
+        zip: "13245",
+        country: "USA",
+      },
+      preferences: [1, 2, 3],
+    },
+    feedback: {
+      feedbackType: "bug_report",
+      description:
+        "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi. Lorem ipsum dolor sit amet,",
+      metadata: {
+        appVersion: "1.0.0",
+        device: "Android",
+        osVer: 14,
+      },
+    },
+    filters: {
+      subobject: {
+        key: "value",
+        nested: {
+          key: "value",
+          array: [
+            {
+              key: "value",
+              nested: { key: "value" },
+            },
+          ],
+        },
+      },
+    },
+  },
 ];

--- a/library/agent/Routes.ts
+++ b/library/agent/Routes.ts
@@ -31,8 +31,11 @@ export class Routes {
     const existing = this.routes.get(key);
 
     if (existing) {
-      // Update body schema if necessary
-      existing.body = updateBodyInfo(context, existing.body);
+      // Only sample first 20 hits of a route during one heartbeat window
+      if (existing.hits <= 20) {
+        // Update body schema if necessary
+        existing.body = updateBodyInfo(context, existing.body);
+      }
 
       existing.hits++;
       return;

--- a/sample-apps/nestjs-sentry/src/cats.controller.ts
+++ b/sample-apps/nestjs-sentry/src/cats.controller.ts
@@ -19,7 +19,6 @@ export class CatsController {
 
   @Post('/cats')
   async postRequest(@Body() body): Promise<string> {
-    console.log(body);
     if (typeof body.name !== 'string') {
       throw new HttpException('Invalid name', 400);
     }


### PR DESCRIPTION
Only sample first 20 hits of a route during one heartbeat window to improve the performance.
Benchmark takes `0.00857ms` on my Mac.