### PR TITLE
Fix not protecting path functions of different os

### DIFF
--- a/library/sinks/Path.test.ts
+++ b/library/sinks/Path.test.ts
@@ -104,4 +104,22 @@ t.test("it works", async (t) => {
       "Zen has blocked a Path traversal: fs.resolve(...) originating from body.file.matches"
     );
   });
+
+  const { join: joinWin } = require("path/win32");
+
+  runWithContext(unsafeAbsoluteContext, () => {
+    t.throws(
+      () => joinWin("/etc/some_directory", "test.txt"),
+      "Zen has blocked a Path traversal: fs.resolve(...) originating from body.file.matches"
+    );
+  });
+
+  const { normalize: normalizePosix } = require("path/posix");
+
+  runWithContext(unsafeContext, () => {
+    t.throws(
+      () => normalizePosix(__dirname, "../test.txt"),
+      "Zen has blocked a Path traversal: fs.join(...) originating from body.file.matches"
+    );
+  });
 });

--- a/library/sinks/Path.ts
+++ b/library/sinks/Path.ts
@@ -34,7 +34,13 @@ export class Path implements Wrapper {
 
   wrap(hooks: Hooks): void {
     hooks
-      .addBuiltinModule("path")
+      .addBuiltinModule("path/posix")
+      .addSubject((exports) => exports)
+      .inspect("join", (args) => this.inspectPath(args, "join"))
+      .inspect("resolve", (args) => this.inspectPath(args, "resolve"))
+      .inspect("normalize", (args) => this.inspectPath(args, "normalize"));
+    hooks
+      .addBuiltinModule("path/win32")
       .addSubject((exports) => exports)
       .inspect("join", (args) => this.inspectPath(args, "join"))
       .inspect("resolve", (args) => this.inspectPath(args, "resolve"))


### PR DESCRIPTION
If you are using Node.js on a POSIX system and import functions from path/win32, they have not been wrapped.