### PR TITLE
Add support for beta releases

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -31,7 +31,8 @@ jobs:
       - name: Get the version
         id: get_version
         run: echo "tag=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
-      - run: cd library && npm --no-git-tag-version version ${{ steps.get_version.outputs.tag }}
+      - name: Set the version
+        run: cd library && npm --no-git-tag-version version ${{ steps.get_version.outputs.tag }}
       - name: Build the library
         run: make build
       - name: Linting
@@ -39,6 +40,7 @@ jobs:
       - name: Publish to NPM
         run: |
           if [ "${{ github.event.release.prerelease }}" = "true" ]; then
+            echo "Publishing beta version"
             cd build && npm publish --provenance --access public --tag beta
           else
             cd build && npm publish --provenance --access public

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -40,9 +40,10 @@ jobs:
       - name: Publish to NPM
         run: |
           if [ "${{ github.event.release.prerelease }}" = "true" ]; then
-            echo "Publishing beta version"
+            echo "Publishing beta version ${{ steps.get_version.outputs.tag }} to NPM"
             cd build && npm publish --provenance --access public --tag beta
           else
+            echo "Publishing version ${{ steps.get_version.outputs.tag }} to NPM"
             cd build && npm publish --provenance --access public
           fi
         env:

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -26,13 +26,22 @@ jobs:
           node-version: "18.x"
           registry-url: "https://registry.npmjs.org"
           scope: "@aikidosec"
-      - run: make install
+      - name: Install dependencies
+        run: make install
       - name: Get the version
         id: get_version
-        run: echo ::set-output name=tag::${GITHUB_REF/refs\/tags\//}
+        run: echo "tag=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
       - run: cd library && npm --no-git-tag-version version ${{ steps.get_version.outputs.tag }}
-      - run: make build
-      - run: make lint
-      - run: cd build && npm publish --provenance --access public
+      - name: Build the library
+        run: make build
+      - name: Linting
+        run: make lint
+      - name: Publish to NPM
+        run: |
+          if [ "${{ github.event.release.prerelease }}" = "true" ]; then
+            cd build && npm publish --provenance --access public --tag beta
+          else
+            cd build && npm publish --provenance --access public
+          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}


### PR DESCRIPTION
If a created release is marked as "prerelease", it will be published to npm with the beta tag (instead of latest).
The tag name is still the version name, so the publisher should add a beta suffix e.g. `-beta.0`.

Tested as well as possible in a private GitHub repository.