### PR TITLE
Use environment variable to check if next is handling requests

### DIFF
--- a/library/sources/HTTP2Server.test.ts
+++ b/library/sources/HTTP2Server.test.ts
@@ -54,7 +54,7 @@ const { readFileSync } = require("fs");
 
 t.beforeEach(() => {
   delete process.env.AIKIDO_MAX_BODY_SIZE_MB;
-  delete process.env.NEXT_RUNTIME;
+  delete process.env.NEXT_DEPLOYMENT_ID;
 });
 
 let _client: ReturnType<typeof connect> | undefined;
@@ -246,7 +246,7 @@ t.test("it parses cookies", async () => {
 
 t.test("it sets body in context", async () => {
   // Enables body parsing
-  process.env.NEXT_RUNTIME = "nodejs";
+  process.env.NEXT_DEPLOYMENT_ID = "";
 
   const server = createMinimalTestServer();
 
@@ -271,7 +271,7 @@ t.test("it sets body in context", async () => {
 
 t.test("it sends 413 when body is larger than 20 Mb", async () => {
   // Enables body parsing
-  process.env.NEXT_RUNTIME = "nodejs";
+  process.env.NEXT_DEPLOYMENT_ID = "";
 
   const server = createMinimalTestServer();
 

--- a/library/sources/HTTP2Server.test.ts
+++ b/library/sources/HTTP2Server.test.ts
@@ -11,17 +11,6 @@ import { resolve } from "path";
 import { FileSystem } from "../sinks/FileSystem";
 import { createTestAgent } from "../helpers/createTestAgent";
 
-const originalIsPackageInstalled = pkg.isPackageInstalled;
-wrap(pkg, "isPackageInstalled", function wrap() {
-  return function wrap(name: string) {
-    // So that it thinks next is installed
-    if (name === "next") {
-      return true;
-    }
-    return originalIsPackageInstalled(name);
-  };
-});
-
 // Allow self-signed certificates
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
 
@@ -65,6 +54,7 @@ const { readFileSync } = require("fs");
 
 t.beforeEach(() => {
   delete process.env.AIKIDO_MAX_BODY_SIZE_MB;
+  delete process.env.NEXT_RUNTIME;
 });
 
 let _client: ReturnType<typeof connect> | undefined;
@@ -255,6 +245,9 @@ t.test("it parses cookies", async () => {
 });
 
 t.test("it sets body in context", async () => {
+  // Enables body parsing
+  process.env.NEXT_RUNTIME = "nodejs";
+
   const server = createMinimalTestServer();
 
   await new Promise<void>((resolve) => {
@@ -277,6 +270,9 @@ t.test("it sets body in context", async () => {
 });
 
 t.test("it sends 413 when body is larger than 20 Mb", async () => {
+  // Enables body parsing
+  process.env.NEXT_RUNTIME = "nodejs";
+
   const server = createMinimalTestServer();
 
   await new Promise<void>((resolve) => {

--- a/library/sources/HTTPServer.test.ts
+++ b/library/sources/HTTPServer.test.ts
@@ -3,17 +3,6 @@ import { wrap } from "../helpers/wrap";
 import * as pkg from "../helpers/isPackageInstalled";
 import { getMajorNodeVersion } from "../helpers/getNodeVersion";
 
-const originalIsPackageInstalled = pkg.isPackageInstalled;
-wrap(pkg, "isPackageInstalled", function wrap() {
-  return function wrap(name: string) {
-    // So that it thinks next is installed
-    if (name === "next") {
-      return true;
-    }
-    return originalIsPackageInstalled(name);
-  };
-});
-
 import * as t from "tap";
 import { ReportingAPIForTesting } from "../agent/api/ReportingAPIForTesting";
 import { getContext } from "../agent/Context";
@@ -61,6 +50,7 @@ t.setTimeout(30 * 1000);
 t.beforeEach(() => {
   delete process.env.AIKIDO_MAX_BODY_SIZE_MB;
   delete process.env.NODE_ENV;
+  delete process.env.NEXT_RUNTIME;
 });
 
 const http = require("http") as typeof import("http");
@@ -315,6 +305,9 @@ t.test("it uses x-forwarded-for header", async (t) => {
 });
 
 t.test("it sets body in context", async (t) => {
+  // Enables body parsing
+  process.env.NEXT_RUNTIME = "nodejs";
+
   const server = http.createServer((req, res) => {
     res.setHeader("Content-Type", "application/json");
     res.end(JSON.stringify(getContext()));
@@ -348,6 +341,9 @@ function generateJsonPayload(sizeInMb: number) {
 }
 
 t.test("it sends 413 when body is larger than 20 Mb", async (t) => {
+  // Enables body parsing
+  process.env.NEXT_RUNTIME = "nodejs";
+
   const server = http.createServer((req, res) => {
     t.fail();
   });
@@ -376,6 +372,9 @@ t.test("it sends 413 when body is larger than 20 Mb", async (t) => {
 });
 
 t.test("body that is not JSON is ignored", async (t) => {
+  // Enables body parsing
+  process.env.NEXT_RUNTIME = "nodejs";
+
   const server = http.createServer((req, res) => {
     res.setHeader("Content-Type", "application/json");
     res.end(JSON.stringify(getContext()));
@@ -402,6 +401,9 @@ t.test("body that is not JSON is ignored", async (t) => {
 });
 
 t.test("it uses limit from AIKIDO_MAX_BODY_SIZE_MB", async (t) => {
+  // Enables body parsing
+  process.env.NEXT_RUNTIME = "nodejs";
+
   const server = http.createServer((req, res) => {
     res.end();
   });

--- a/library/sources/HTTPServer.test.ts
+++ b/library/sources/HTTPServer.test.ts
@@ -1,6 +1,4 @@
 import { Token } from "../agent/api/Token";
-import { wrap } from "../helpers/wrap";
-import * as pkg from "../helpers/isPackageInstalled";
 import { getMajorNodeVersion } from "../helpers/getNodeVersion";
 
 import * as t from "tap";

--- a/library/sources/HTTPServer.test.ts
+++ b/library/sources/HTTPServer.test.ts
@@ -50,7 +50,7 @@ t.setTimeout(30 * 1000);
 t.beforeEach(() => {
   delete process.env.AIKIDO_MAX_BODY_SIZE_MB;
   delete process.env.NODE_ENV;
-  delete process.env.NEXT_RUNTIME;
+  delete process.env.NEXT_DEPLOYMENT_ID;
 });
 
 const http = require("http") as typeof import("http");
@@ -306,7 +306,7 @@ t.test("it uses x-forwarded-for header", async (t) => {
 
 t.test("it sets body in context", async (t) => {
   // Enables body parsing
-  process.env.NEXT_RUNTIME = "nodejs";
+  process.env.NEXT_DEPLOYMENT_ID = "";
 
   const server = http.createServer((req, res) => {
     res.setHeader("Content-Type", "application/json");
@@ -342,7 +342,7 @@ function generateJsonPayload(sizeInMb: number) {
 
 t.test("it sends 413 when body is larger than 20 Mb", async (t) => {
   // Enables body parsing
-  process.env.NEXT_RUNTIME = "nodejs";
+  process.env.NEXT_DEPLOYMENT_ID = "";
 
   const server = http.createServer((req, res) => {
     t.fail();
@@ -373,7 +373,7 @@ t.test("it sends 413 when body is larger than 20 Mb", async (t) => {
 
 t.test("body that is not JSON is ignored", async (t) => {
   // Enables body parsing
-  process.env.NEXT_RUNTIME = "nodejs";
+  process.env.NEXT_DEPLOYMENT_ID = "";
 
   const server = http.createServer((req, res) => {
     res.setHeader("Content-Type", "application/json");
@@ -402,7 +402,7 @@ t.test("body that is not JSON is ignored", async (t) => {
 
 t.test("it uses limit from AIKIDO_MAX_BODY_SIZE_MB", async (t) => {
   // Enables body parsing
-  process.env.NEXT_RUNTIME = "nodejs";
+  process.env.NEXT_DEPLOYMENT_ID = "";
 
   const server = http.createServer((req, res) => {
     res.end();

--- a/library/sources/HTTPServer.ts
+++ b/library/sources/HTTPServer.ts
@@ -3,36 +3,21 @@ import { Hooks } from "../agent/hooks/Hooks";
 import { wrapExport } from "../agent/hooks/wrapExport";
 import { wrapNewInstance } from "../agent/hooks/wrapNewInstance";
 import { Wrapper } from "../agent/Wrapper";
-import { isPackageInstalled } from "../helpers/isPackageInstalled";
 import { createRequestListener } from "./http-server/createRequestListener";
 import { createStreamListener } from "./http-server/http2/createStreamListener";
 
 export class HTTPServer implements Wrapper {
-  private isNextJS() {
-    return process.env.NEXT_RUNTIME && process.env.NEXT_RUNTIME.length > 0;
-  }
-
   private wrapRequestListener(args: unknown[], module: string, agent: Agent) {
-    // Parse body only if next is installed
-    // We can only read the body stream once
-    // This is tricky, see replaceRequestBody(...)
-    // e.g. Hono uses web requests and web streams
-    // (uses Readable.toWeb(req) to convert to a web stream)
-    const parseBody = this.isNextJS() || isPackageInstalled("micro");
-
     // Without options
     // http(s).createServer(listener)
     if (args.length > 0 && typeof args[0] === "function") {
-      return [createRequestListener(args[0], module, agent, parseBody)];
+      return [createRequestListener(args[0], module, agent)];
     }
 
     // With options
     // http(s).createServer({ ... }, listener)
     if (args.length > 1 && typeof args[1] === "function") {
-      return [
-        args[0],
-        createRequestListener(args[1], module, agent, parseBody),
-      ];
+      return [args[0], createRequestListener(args[1], module, agent)];
     }
 
     return args;

--- a/library/sources/HTTPServer.ts
+++ b/library/sources/HTTPServer.ts
@@ -8,13 +8,17 @@ import { createRequestListener } from "./http-server/createRequestListener";
 import { createStreamListener } from "./http-server/http2/createStreamListener";
 
 export class HTTPServer implements Wrapper {
+  private isNextJS() {
+    return process.env.NEXT_RUNTIME && process.env.NEXT_RUNTIME.length > 0;
+  }
+
   private wrapRequestListener(args: unknown[], module: string, agent: Agent) {
     // Parse body only if next is installed
     // We can only read the body stream once
     // This is tricky, see replaceRequestBody(...)
     // e.g. Hono uses web requests and web streams
     // (uses Readable.toWeb(req) to convert to a web stream)
-    const parseBody = isPackageInstalled("next") || isPackageInstalled("micro");
+    const parseBody = this.isNextJS() || isPackageInstalled("micro");
 
     // Without options
     // http(s).createServer(listener)

--- a/library/sources/http-server/createRequestListener.ts
+++ b/library/sources/http-server/createRequestListener.ts
@@ -2,6 +2,7 @@ import type { IncomingMessage, RequestListener, ServerResponse } from "http";
 import { Agent } from "../../agent/Agent";
 import { bindContext, getContext, runWithContext } from "../../agent/Context";
 import { escapeHTML } from "../../helpers/escapeHTML";
+import { isPackageInstalled } from "../../helpers/isPackageInstalled";
 import { contextFromRequest } from "./contextFromRequest";
 import { ipAllowedToAccessRoute } from "./ipAllowedToAccessRoute";
 import { readBodyStream } from "./readBodyStream";
@@ -10,10 +11,18 @@ import { shouldDiscoverRoute } from "./shouldDiscoverRoute";
 export function createRequestListener(
   listener: Function,
   module: string,
-  agent: Agent,
-  readBody: boolean
+  agent: Agent
 ): RequestListener {
+  const isMicroInstalled = isPackageInstalled("micro");
+
   return async function requestListener(req, res) {
+    // Parse body only if next or micro is installed
+    // We can only read the body stream once
+    // This is tricky, see replaceRequestBody(...)
+    // e.g. Hono uses web requests and web streams
+    // (uses Readable.toWeb(req) to convert to a web stream)
+    const readBody = "NEXT_DEPLOYMENT_ID" in process.env || isMicroInstalled;
+
     if (!readBody) {
       return callListenerWithContext(listener, req, res, module, agent, "");
     }


### PR DESCRIPTION
In monorepo's with many packages, it could be that next is used in a separate package (e.g. their website)

If we use `require.resolve("next")` it will return a path and thus start reading bodies

For micro, there's no way to know if it's micro (`require("micro")` does not happen nor is there an env variable)

For micro, we can add a separate function handler to improve (similar to lambda and google function).