### PR TITLE
Remove require() call from GraphQL source

### DIFF
--- a/end2end/tests/express-graphql.test.js
+++ b/end2end/tests/express-graphql.test.js
@@ -10,7 +10,7 @@ const pathToApp = resolve(
 );
 
 t.test("it blocks in blocking mode", (t) => {
-  const server = spawn(`node`, ["--preserve-symlinks", pathToApp, "4000"], {
+  const server = spawn(`node`, [pathToApp, "4000"], {
     env: { ...process.env, AIKIDO_DEBUG: "true", AIKIDO_BLOCKING: "true" },
   });
 

--- a/library/sources/graphql/extractInputsFromDocument.test.ts
+++ b/library/sources/graphql/extractInputsFromDocument.test.ts
@@ -14,6 +14,8 @@ import {
 } from "graphql";
 import { extractInputsFromDocument } from "./extractInputsFromDocument";
 
+import { visit as visitFn } from "graphql";
+
 const AddressType = new GraphQLObjectType({
   name: "Address",
   fields: {
@@ -129,7 +131,7 @@ t.test("it returns correct user inputs", (t) => {
   }
 
   // Extract user inputs from the document
-  const inputs = extractInputsFromDocument(document);
+  const inputs = extractInputsFromDocument(document, visitFn);
 
   t.equal(inputs.length, 1);
   t.equal(inputs[0], "teststring");
@@ -158,7 +160,7 @@ t.test("it returns correct user inputs for different queries", (t) => {
     return;
   }
 
-  const inputs = extractInputsFromDocument(document);
+  const inputs = extractInputsFromDocument(document, visitFn);
 
   t.equal(inputs.length, 1);
   t.equal(inputs[0], "12345");
@@ -182,7 +184,7 @@ t.test("it returns correct user inputs for mutations", (t) => {
     return;
   }
 
-  const inputs = extractInputsFromDocument(document);
+  const inputs = extractInputsFromDocument(document, visitFn);
 
   t.equal(inputs.length, 1);
   t.same(inputs, ["John Doe"]);
@@ -206,7 +208,7 @@ t.test("it handles nested inputs and mutations", (t) => {
     return;
   }
 
-  const inputs = extractInputsFromDocument(document);
+  const inputs = extractInputsFromDocument(document, visitFn);
 
   t.equal(inputs.length, 2);
   t.same(inputs, ["123 Main St", "Metropolis"]);
@@ -230,7 +232,7 @@ t.test("it handles list query with argument", (t) => {
     return;
   }
 
-  const inputs = extractInputsFromDocument(document);
+  const inputs = extractInputsFromDocument(document, visitFn);
 
   t.equal(inputs.length, 1);
   t.same(inputs, ["Wesel"]);
@@ -254,7 +256,7 @@ t.test("it handles list values in mutations", (t) => {
     return;
   }
 
-  const inputs = extractInputsFromDocument(document);
+  const inputs = extractInputsFromDocument(document, visitFn);
 
   t.equal(inputs.length, 4);
   t.same(inputs, ["1", "2", "3", "Software Engineer"]);
@@ -285,7 +287,7 @@ t.test("it handles queries with FragmentDefinition and InlineFragment", (t) => {
     return;
   }
 
-  const inputs = extractInputsFromDocument(document);
+  const inputs = extractInputsFromDocument(document, visitFn);
 
   t.equal(inputs.length, 1);
   t.same(inputs, ["user123"]);
@@ -313,7 +315,7 @@ t.test("it handles nested query with argument", (t) => {
     return;
   }
 
-  const inputs = extractInputsFromDocument(document);
+  const inputs = extractInputsFromDocument(document, visitFn);
 
   t.equal(inputs.length, 1);
   t.same(inputs, ["NestedCity"]);
@@ -337,7 +339,7 @@ t.test("it parses default values for string arguments", (t) => {
     return;
   }
 
-  const inputs = extractInputsFromDocument(document);
+  const inputs = extractInputsFromDocument(document, visitFn);
 
   t.same(inputs, ["default"]);
   t.end();

--- a/library/sources/graphql/extractInputsFromDocument.ts
+++ b/library/sources/graphql/extractInputsFromDocument.ts
@@ -4,18 +4,12 @@ import type { DocumentNode, StringValueNode } from "graphql";
  * This function extracts user inputs (that could be harmful) from a GraphQL document.
  * @returns An array of user inputs.
  */
-export function extractInputsFromDocument(document: DocumentNode): string[] {
-  let graphql;
-  try {
-    // Assuming graphql is installed when this function is called
-    // Don't use normal import for graphql
-    graphql = require("graphql");
-  } catch (e) {
-    return [];
-  }
-
+export function extractInputsFromDocument(
+  document: DocumentNode,
+  visitFn: typeof import("graphql").visit
+): string[] {
   const inputs: string[] = [];
-  graphql.visit(document, {
+  visitFn(document, {
     StringValue(node: StringValueNode) {
       inputs.push(node.value);
     },


### PR DESCRIPTION
Adjustment of the behavior to the new hook system. Makes `--preserve-symlinks` no longer necessary in tests.