### PR TITLE
Perf opt: Check containsPrivateIPAddress(hostname) at start

### DIFF
--- a/library/vulnerabilities/ssrf/checkContextForSSRF.ts
+++ b/library/vulnerabilities/ssrf/checkContextForSSRF.ts
@@ -21,6 +21,10 @@ export function checkContextForSSRF({
   operation: string;
   context: Context;
 }): InterceptorResult {
+  // If the hostname is a private IP address, we don't need to check for SSRF
+  // DNS lookup calls will be inspected somewhere else
+  // This is just to inspect direct invocations of `http.request` and similar
+  // Where the hostname might be a private IP address (or localhost)
   if (!containsPrivateIPAddress(hostname)) {
     return;
   }

--- a/library/vulnerabilities/ssrf/checkContextForSSRF.ts
+++ b/library/vulnerabilities/ssrf/checkContextForSSRF.ts
@@ -21,6 +21,10 @@ export function checkContextForSSRF({
   operation: string;
   context: Context;
 }): InterceptorResult {
+  if (!containsPrivateIPAddress(hostname)) {
+    return;
+  }
+
   for (const source of SOURCES) {
     const userInput = extractStringsFromUserInputCached(context, source);
     if (!userInput) {
@@ -29,7 +33,7 @@ export function checkContextForSSRF({
 
     for (const [str, path] of userInput.entries()) {
       const found = findHostnameInUserInput(str, hostname, port);
-      if (found && containsPrivateIPAddress(hostname)) {
+      if (found) {
         return {
           operation: operation,
           kind: "ssrf",

--- a/library/vulnerabilities/ssrf/checkContextForSSRF.ts
+++ b/library/vulnerabilities/ssrf/checkContextForSSRF.ts
@@ -21,7 +21,7 @@ export function checkContextForSSRF({
   operation: string;
   context: Context;
 }): InterceptorResult {
-  // If the hostname is a private IP address, we don't need to check for SSRF
+  // If the hostname is not a private IP address, we don't need to iterate over the user input
   // DNS lookup calls will be inspected somewhere else
   // This is just to inspect direct invocations of `http.request` and similar
   // Where the hostname might be a private IP address (or localhost)


### PR DESCRIPTION
We don't need to iterate over the user input if the hostname is not a private IP address.