### PR TITLE
Use process.nextTick before wrapping Collection (mongodb v6.10.0)

### DIFF
--- a/library/package-lock.json
+++ b/library/package-lock.json
@@ -61,7 +61,7 @@
         "mongodb": "~6.9",
         "mongodb-v4": "npm:mongodb@^4.0.0",
         "mongodb-v5": "npm:mongodb@^5.0.0",
-        "mongodb-v6": "npm:mongodb@~6.9",
+        "mongodb-v6": "npm:mongodb@^6.0.0",
         "mysql": "^2.18.1",
         "mysql2": "^3.10.0",
         "needle": "^3.3.1",
@@ -11838,13 +11838,13 @@
     },
     "node_modules/mongodb-v6": {
       "name": "mongodb",
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.9.0.tgz",
-      "integrity": "sha512-UMopBVx1LmEUbW/QE0Hw18u583PEDVQmUmVzzBRH0o/xtE9DBRA5ZYLOjpLIa03i8FXjzvQECJcqoMvCXftTUA==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.11.0.tgz",
+      "integrity": "sha512-yVbPw0qT268YKhG241vAMLaDQAPbRyTgo++odSgGc9kXnzOujQI60Iyj23B9sQQFPSvmNPvMZ3dsFz0aN55KgA==",
       "dev": true,
       "dependencies": {
-        "@mongodb-js/saslprep": "^1.1.5",
-        "bson": "^6.7.0",
+        "@mongodb-js/saslprep": "^1.1.9",
+        "bson": "^6.10.0",
         "mongodb-connection-string-url": "^3.0.0"
       },
       "engines": {

--- a/library/package.json
+++ b/library/package.json
@@ -110,12 +110,12 @@
     "tap": "^18.6.1",
     "type-fest": "^4.24.0",
     "typescript": "^5.3.3",
+    "xml-js": "^1.6.11",
+    "xml2js": "^0.6.2",
     "undici-v4": "npm:undici@^4.0.0",
     "undici-v5": "npm:undici@^5.0.0",
     "undici-v6": "npm:undici@^6.0.0",
-    "undici-v7": "npm:undici@^7.0.0",
-    "xml-js": "^1.6.11",
-    "xml2js": "^0.6.2"
+    "undici-v7": "npm:undici@^7.0.0"
   },
   "scripts": {
     "test": "node ../scripts/run-tap.js",

--- a/library/package.json
+++ b/library/package.json
@@ -94,7 +94,7 @@
     "mongodb": "~6.9",
     "mongodb-v4": "npm:mongodb@^4.0.0",
     "mongodb-v5": "npm:mongodb@^5.0.0",
-    "mongodb-v6": "npm:mongodb@~6.9",
+    "mongodb-v6": "npm:mongodb@^6.0.0",
     "mysql": "^2.18.1",
     "mysql2": "^3.10.0",
     "needle": "^3.3.1",
@@ -110,12 +110,12 @@
     "tap": "^18.6.1",
     "type-fest": "^4.24.0",
     "typescript": "^5.3.3",
-    "xml-js": "^1.6.11",
-    "xml2js": "^0.6.2",
     "undici-v4": "npm:undici@^4.0.0",
     "undici-v5": "npm:undici@^5.0.0",
     "undici-v6": "npm:undici@^6.0.0",
-    "undici-v7": "npm:undici@^7.0.0"
+    "undici-v7": "npm:undici@^7.0.0",
+    "xml-js": "^1.6.11",
+    "xml2js": "^0.6.2"
   },
   "scripts": {
     "test": "node ../scripts/run-tap.js",

--- a/library/sinks/MongoDB.ts
+++ b/library/sinks/MongoDB.ts
@@ -2,6 +2,7 @@
 import type { Collection } from "mongodb-v6";
 import { Hooks } from "../agent/hooks/Hooks";
 import { InterceptorResult } from "../agent/hooks/InterceptorResult";
+import type { WrapPackageInfo } from "../agent/hooks/WrapPackageInfo";
 import { detectNoSQLInjection } from "../vulnerabilities/nosql-injection/detectNoSQLInjection";
 import { isPlainObject } from "../helpers/isPlainObject";
 import { Context, getContext } from "../agent/Context";
@@ -186,33 +187,42 @@ export class MongoDB implements Wrapper {
     return undefined;
   }
 
+  private wrapCollection(
+    exports: typeof import("mongodb-v6"),
+    pkgInfo: WrapPackageInfo
+  ) {
+    const collectionProto = exports.Collection.prototype;
+
+    OPERATIONS_WITH_FILTER.forEach((operation) => {
+      wrapExport(collectionProto, operation, pkgInfo, {
+        inspectArgs: (args, agent, collection) =>
+          this.inspectOperation(operation, args, collection as Collection),
+      });
+    });
+
+    wrapExport(collectionProto, "bulkWrite", pkgInfo, {
+      inspectArgs: (args, agent, collection) =>
+        this.inspectBulkWrite(args, collection as Collection),
+    });
+
+    wrapExport(collectionProto, "aggregate", pkgInfo, {
+      inspectArgs: (args, agent, collection) =>
+        this.inspectAggregate(args, collection as Collection),
+    });
+
+    wrapExport(collectionProto, "distinct", pkgInfo, {
+      inspectArgs: (args, agent, collection) =>
+        this.inspectDistinct(args, collection as Collection),
+    });
+  }
+
   wrap(hooks: Hooks) {
     hooks
       .addPackage("mongodb")
       .withVersion("^4.0.0 || ^5.0.0 || ^6.0.0")
       .onRequire((exports, pkgInfo) => {
-        const collectionProto = exports.Collection.prototype;
-
-        OPERATIONS_WITH_FILTER.forEach((operation) => {
-          wrapExport(collectionProto, operation, pkgInfo, {
-            inspectArgs: (args, agent, collection) =>
-              this.inspectOperation(operation, args, collection as Collection),
-          });
-        });
-
-        wrapExport(collectionProto, "bulkWrite", pkgInfo, {
-          inspectArgs: (args, agent, collection) =>
-            this.inspectBulkWrite(args, collection as Collection),
-        });
-
-        wrapExport(collectionProto, "aggregate", pkgInfo, {
-          inspectArgs: (args, agent, collection) =>
-            this.inspectAggregate(args, collection as Collection),
-        });
-
-        wrapExport(collectionProto, "distinct", pkgInfo, {
-          inspectArgs: (args, agent, collection) =>
-            this.inspectDistinct(args, collection as Collection),
+        process.nextTick(() => {
+          this.wrapCollection(exports, pkgInfo);
         });
       });
   }

--- a/library/sinks/MongoDB.ts
+++ b/library/sinks/MongoDB.ts
@@ -221,6 +221,12 @@ export class MongoDB implements Wrapper {
       .addPackage("mongodb")
       .withVersion("^4.0.0 || ^5.0.0 || ^6.0.0")
       .onRequire((exports, pkgInfo) => {
+        // From mongodb v6.10.0, the Collection is undefined
+        // It's defined like:
+        // exports.Collection = void 0;
+        // const collection_1 = require("./collection");
+        // Object.defineProperty(exports, "Collection", { enumerable: true, get: function () { return collection_1.Collection; } });
+        // So we need to wait for the next tick to wrap the Collection
         process.nextTick(() => {
           this.wrapCollection(exports, pkgInfo);
         });

--- a/sample-apps/hono-mongodb/package-lock.json
+++ b/sample-apps/hono-mongodb/package-lock.json
@@ -8,7 +8,7 @@
         "@aikidosec/firewall": "file:../../build",
         "@hono/node-server": "^1.11.2",
         "hono": "^4.4.2",
-        "mongodb": "^6.3.0"
+        "mongodb": "^6.11.0"
       }
     },
     "../../build": {
@@ -60,10 +60,9 @@
       }
     },
     "node_modules/bson": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-6.8.0.tgz",
-      "integrity": "sha512-iOJg8pr7wq2tg/zSlCCHMi3hMm5JTOxLTagf3zxhcenHsFp+c6uOs6K7W5UE7A4QIJGtqh/ZovFNMP4mOPJynQ==",
-      "license": "Apache-2.0",
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.1.tgz",
+      "integrity": "sha512-P92xmHDQjSKPLHqFxefqMxASNq/aWJMEZugpCjf+AF/pgcUpMMQCg7t7+ewko0/u8AapvF3luf/FoehddEK+sA==",
       "engines": {
         "node": ">=16.20.1"
       }
@@ -84,13 +83,12 @@
       "license": "MIT"
     },
     "node_modules/mongodb": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.8.0.tgz",
-      "integrity": "sha512-HGQ9NWDle5WvwMnrvUxsFYPd3JEbqD3RgABHBQRuoCEND0qzhsd0iH5ypHsf1eJ+sXmvmyKpP+FLOKY8Il7jMw==",
-      "license": "Apache-2.0",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.11.0.tgz",
+      "integrity": "sha512-yVbPw0qT268YKhG241vAMLaDQAPbRyTgo++odSgGc9kXnzOujQI60Iyj23B9sQQFPSvmNPvMZ3dsFz0aN55KgA==",
       "dependencies": {
-        "@mongodb-js/saslprep": "^1.1.5",
-        "bson": "^6.7.0",
+        "@mongodb-js/saslprep": "^1.1.9",
+        "bson": "^6.10.0",
         "mongodb-connection-string-url": "^3.0.0"
       },
       "engines": {

--- a/sample-apps/hono-mongodb/package.json
+++ b/sample-apps/hono-mongodb/package.json
@@ -3,6 +3,6 @@
     "@aikidosec/firewall": "file:../../build",
     "@hono/node-server": "^1.11.2",
     "hono": "^4.4.2",
-    "mongodb": "^6.3.0"
+    "mongodb": "^6.11.0"
   }
 }


### PR DESCRIPTION
```js
exports.Collection = void 0;
const collection_1 = require("./collection");
Object.defineProperty(exports, "Collection", { enumerable: true, get: function () { return collection_1.Collection; } });
```

For some reason the Collection is undefined in our callback, let's wait until the next tick to grab a reference to Collection.