### PR TITLE
Detect sensitive file access

### DIFF
--- a/library/agent/Attack.ts
+++ b/library/agent/Attack.ts
@@ -4,7 +4,8 @@ export type Kind =
   | "shell_injection"
   | "path_traversal"
   | "ssrf"
-  | "js_injection";
+  | "js_injection"
+  | "sensitive_file_access";
 
 export function attackKindHumanName(kind: Kind) {
   switch (kind) {
@@ -20,5 +21,7 @@ export function attackKindHumanName(kind: Kind) {
       return "a server-side request forgery";
     case "js_injection":
       return "a JavaScript injection";
+    case "sensitive_file_access":
+      return "a sensitive file access";
   }
 }

--- a/library/helpers/pathToString.ts
+++ b/library/helpers/pathToString.ts
@@ -1,0 +1,24 @@
+/**
+ * Convert a fs path argument (string, Buffer, URL) to a string
+ */
+export function pathToString(path: string | Buffer | URL): string | undefined {
+  if (typeof path === "string") {
+    return path;
+  }
+
+  if (path instanceof URL) {
+    return path.pathname;
+  }
+
+  if (path instanceof Buffer) {
+    try {
+      return new TextDecoder("utf-8", {
+        fatal: true,
+      }).decode(path);
+    } catch (e) {
+      return undefined;
+    }
+  }
+
+  return undefined;
+}

--- a/library/sinks/Path.test.ts
+++ b/library/sinks/Path.test.ts
@@ -3,7 +3,6 @@ import { Context, runWithContext } from "../agent/Context";
 import { isWrapped } from "../helpers/wrap";
 import { Path } from "./Path";
 import { createTestAgent } from "../helpers/createTestAgent";
-import { getMajorNodeVersion } from "../helpers/getNodeVersion";
 
 const unsafeContext: Context = {
   remoteAddress: "::1",

--- a/library/vulnerabilities/path-traversal/checkContextForPathTraversal.ts
+++ b/library/vulnerabilities/path-traversal/checkContextForPathTraversal.ts
@@ -3,6 +3,7 @@ import { InterceptorResult } from "../../agent/hooks/InterceptorResult";
 import { SOURCES } from "../../agent/Source";
 import { getPathsToPayload } from "../../helpers/attackPath";
 import { extractStringsFromUserInputCached } from "../../helpers/extractStringsFromUserInputCached";
+import { pathToString } from "../../helpers/pathToString";
 import { detectPathTraversal } from "./detectPathTraversal";
 
 /**
@@ -47,29 +48,4 @@ export function checkContextForPathTraversal({
       }
     }
   }
-}
-
-/**
- * Convert a fs path argument (string, Buffer, URL) to a string
- */
-function pathToString(path: string | Buffer | URL): string | undefined {
-  if (typeof path === "string") {
-    return path;
-  }
-
-  if (path instanceof URL) {
-    return path.pathname;
-  }
-
-  if (path instanceof Buffer) {
-    try {
-      return new TextDecoder("utf-8", {
-        fatal: true,
-      }).decode(path);
-    } catch (e) {
-      return undefined;
-    }
-  }
-
-  return undefined;
 }

--- a/library/vulnerabilities/sensitive-file-access/getMatchingPathEnding.test.ts
+++ b/library/vulnerabilities/sensitive-file-access/getMatchingPathEnding.test.ts
@@ -1,0 +1,26 @@
+import * as t from "tap";
+import { getMatchingPathEnding as get } from "./getMatchingPathEnding";
+
+t.test("it works", async (t) => {
+  t.same(get("/a/b/c", "/a/b/c"), "/a/b/c");
+  t.same(get("/a/b", "/a/b/c"), undefined);
+  t.same(get("/a/b/c", "/b/c"), "/b/c");
+
+  t.same(
+    get("/static/test/file.txt", "/static/test/file.txt"),
+    "/static/test/file.txt"
+  );
+  t.same(
+    get("/static/test/file.txt", "/opt/app/data/static/test/file.txt"),
+    "/static/test/file.txt"
+  );
+  t.same(
+    get("/static/test/file.txt", "/opt/app/data/test/file.txt"),
+    "/test/file.txt"
+  );
+  t.same(get("/static/test/file.txt", "/file.txt"), "/file.txt");
+  t.same(get("/static/test/file.txt", "file.txt"), "/file.txt");
+
+  t.same(get("/static/test/file.txt", "abc.txt"), undefined);
+  t.same(get("/static/test/file.txt", "file"), undefined);
+});

--- a/library/vulnerabilities/sensitive-file-access/getMatchingPathEnding.ts
+++ b/library/vulnerabilities/sensitive-file-access/getMatchingPathEnding.ts
@@ -1,0 +1,43 @@
+import { normalize } from "path";
+
+export function getMatchingPathEnding(
+  urlPath: string,
+  filePath: string
+): string | undefined {
+  // Normalize slashes to forward slashes for comparison
+  const normalizedUrlPath = normalize(urlPath);
+  const normalizedFilePath = normalize(filePath).replace(/\\/g, "/");
+
+  const reversedUrlParts = normalizedUrlPath.split("/").reverse();
+  const reversedFileParts = normalizedFilePath.split("/").reverse();
+
+  // Create one array with all matching segments from the url path beginning from the end
+  // We can not simply check using filePath.endsWith(urlPath) because the static files could be served in a subdirectory
+  const matchingParts = [];
+
+  for (let i = 0; i < reversedUrlParts.length; i++) {
+    // Break if we reached the beginning of the file path
+    if (i >= reversedFileParts.length) {
+      break;
+    }
+
+    // If the parts match, add it to the matching parts
+    if (reversedUrlParts[i] === reversedFileParts[i]) {
+      matchingParts.push(reversedUrlParts[i]);
+      continue;
+    }
+
+    // Break at the first non-matching part
+    break;
+  }
+
+  if (matchingParts.length === 0) {
+    return undefined;
+  }
+
+  const matchingStr = matchingParts.reverse().join("/");
+  if (!matchingStr.startsWith("/")) {
+    return `/${matchingStr}`;
+  }
+  return matchingStr;
+}

--- a/library/vulnerabilities/sensitive-file-access/isSensitiveFile.test.ts
+++ b/library/vulnerabilities/sensitive-file-access/isSensitiveFile.test.ts
@@ -1,0 +1,20 @@
+import * as t from "tap";
+import { isSensitiveFile } from "./isSensitiveFile";
+
+t.test("is a sensitive file", async (t) => {
+  t.same(isSensitiveFile("/.env"), true);
+  t.same(isSensitiveFile("/.ENV"), true);
+  t.same(isSensitiveFile("/.bashrc"), true);
+  t.same(isSensitiveFile("/.git"), true);
+  t.same(isSensitiveFile("/.git/"), true);
+  t.same(isSensitiveFile("/.git/test"), true);
+});
+
+t.test("is not a sensitive file", async (t) => {
+  t.same(isSensitiveFile("/test"), false);
+  t.same(isSensitiveFile("/.env/"), false);
+  t.same(isSensitiveFile("/.env/test"), false);
+  t.same(isSensitiveFile("/"), false);
+  t.same(isSensitiveFile("/.gitabc"), false);
+  t.same(isSensitiveFile("/.gitabc/test"), false);
+});

--- a/library/vulnerabilities/sensitive-file-access/isSensitiveFile.ts
+++ b/library/vulnerabilities/sensitive-file-access/isSensitiveFile.ts
@@ -1,0 +1,21 @@
+const forbiddenFileNames = [".env", ".bashrc"];
+const forbiddenDirectories = [".git", ".aws"];
+
+const forbiddenFileNamesPattern = `(?:.*/(?:${forbiddenFileNames.join("|")}))`;
+const forbiddenDirectoriesPattern = `(?:.*/(?:${forbiddenDirectories.join("|")})(?:/.*)?)`;
+
+const regex = new RegExp(
+  `^(?:${forbiddenFileNamesPattern}|${forbiddenDirectoriesPattern})$`,
+  "i"
+);
+
+/**
+ * Check if a given url path (absolute) is a sensitive file or directory
+ */
+export function isSensitiveFile(path: string): boolean {
+  if (path.length <= 1) {
+    return false;
+  }
+
+  return regex.test(path);
+}


### PR DESCRIPTION
E.g. files accidentally served using a static middleware, like `.env`