### PR TITLE
Pass body to `req.end(...)` instead of `req.write(...)`

### DIFF
--- a/library/helpers/fetch.ts
+++ b/library/helpers/fetch.ts
@@ -54,8 +54,7 @@ async function request({
       reject(error);
     });
 
-    req.write(body);
-    req.end();
+    req.end(body);
   });
 }
 

--- a/library/sources/HTTPServer.test.ts
+++ b/library/sources/HTTPServer.test.ts
@@ -455,7 +455,7 @@ t.test("it uses limit from AIKIDO_MAX_BODY_SIZE_MB", async (t) => {
           t.equal(response2.statusCode, 413);
         })
         .catch((error) => {
-          t.fail(`Unexpected error: ${error.message} ${error.stack}`);
+          t.fail(error);
         })
         .finally(() => {
           server.close();

--- a/library/sources/HTTPServer.test.ts
+++ b/library/sources/HTTPServer.test.ts
@@ -6,9 +6,14 @@ import { getContext } from "../agent/Context";
 import { fetch } from "../helpers/fetch";
 import { wrap } from "../helpers/wrap";
 import { HTTPServer } from "./HTTPServer";
+import { join } from "path";
 import { createTestAgent } from "../helpers/createTestAgent";
 import type { Blocklist } from "../agent/api/fetchBlockedLists";
 import * as fetchBlockedLists from "../agent/api/fetchBlockedLists";
+import { mkdtemp, writeFile, unlink } from "fs/promises";
+import { exec } from "child_process";
+import { promisify } from "util";
+const execAsync = promisify(exec);
 
 // Before require("http")
 const api = new ReportingAPIForTesting({
@@ -359,17 +364,51 @@ function generateJsonPayload(sizeInMb: number) {
   return JSON.stringify("a".repeat(sizeInBytes));
 }
 
-t.test("it sends 413 when body is larger than 20 Mb", async (t) => {
+// Send request using curl
+// Returns the response message + status code in stdout
+// We need this because http.request throws EPIPE write error when the server closes the connection abruptly
+// We cannot read the status code or the response message when that happens
+async function sendUsingCurl({
+  url,
+  method,
+  headers,
+  body,
+  timeoutInMS,
+}: {
+  url: URL;
+  method: string;
+  headers: Record<string, string>;
+  body: string;
+  timeoutInMS: number;
+}) {
+  const headersString = Object.entries(headers)
+    .map(([key, value]) => `-H "${key}: ${value}"`)
+    .join(" ");
+
+  const tmpDir = await mkdtemp("/tmp/aikido-");
+  const tmpFile = join(tmpDir, "/body.json");
+  await writeFile(tmpFile, body, { encoding: "utf-8" });
+
+  const { stdout } = await execAsync(
+    `curl -X ${method} ${headersString} -d @${tmpFile} ${url} --max-time ${timeoutInMS / 1000} --write-out "%{http_code}"`
+  );
+  await unlink(tmpFile);
+
+  return stdout;
+}
+
+t.only("it sends 413 when body is larger than 20 Mb", async (t) => {
   // Enables body parsing
   process.env.NEXT_DEPLOYMENT_ID = "";
 
   const server = http.createServer((req, res) => {
     t.fail();
+    res.end();
   });
 
   await new Promise<void>((resolve) => {
     server.listen(3320, () => {
-      fetch({
+      sendUsingCurl({
         url: new URL("http://localhost:3320"),
         method: "POST",
         headers: {
@@ -377,15 +416,20 @@ t.test("it sends 413 when body is larger than 20 Mb", async (t) => {
         },
         body: generateJsonPayload(21),
         timeoutInMS: 2000,
-      }).then(({ body, statusCode }) => {
-        t.equal(
-          body,
-          "This request was aborted by Aikido firewall because the body size exceeded the maximum allowed size. Use AIKIDO_MAX_BODY_SIZE_MB to increase the limit."
-        );
-        t.equal(statusCode, 413);
-        server.close();
-        resolve();
-      });
+      })
+        .then((stdout) => {
+          t.equal(
+            stdout,
+            "This request was aborted by Aikido firewall because the body size exceeded the maximum allowed size. Use AIKIDO_MAX_BODY_SIZE_MB to increase the limit.413"
+          );
+        })
+        .catch((error) => {
+          t.fail(error);
+        })
+        .finally(() => {
+          server.close();
+          resolve();
+        });
     });
   });
 });
@@ -431,7 +475,7 @@ t.test("it uses limit from AIKIDO_MAX_BODY_SIZE_MB", async (t) => {
     server.listen(3322, () => {
       process.env.AIKIDO_MAX_BODY_SIZE_MB = "1";
       Promise.all([
-        fetch({
+        sendUsingCurl({
           url: new URL("http://localhost:3322"),
           method: "POST",
           headers: {
@@ -440,7 +484,7 @@ t.test("it uses limit from AIKIDO_MAX_BODY_SIZE_MB", async (t) => {
           body: generateJsonPayload(1),
           timeoutInMS: 2000,
         }),
-        fetch({
+        sendUsingCurl({
           url: new URL("http://localhost:3322"),
           method: "POST",
           headers: {
@@ -451,8 +495,11 @@ t.test("it uses limit from AIKIDO_MAX_BODY_SIZE_MB", async (t) => {
         }),
       ])
         .then(([response1, response2]) => {
-          t.equal(response1.statusCode, 200);
-          t.equal(response2.statusCode, 413);
+          t.equal(response1, "200");
+          t.same(
+            response2,
+            "This request was aborted by Aikido firewall because the body size exceeded the maximum allowed size. Use AIKIDO_MAX_BODY_SIZE_MB to increase the limit.413"
+          );
         })
         .catch((error) => {
           t.fail(error);

--- a/library/sources/http-server/readBodyStream.ts
+++ b/library/sources/http-server/readBodyStream.ts
@@ -28,7 +28,10 @@ export async function readBodyStream(
       if (bodySize + chunk.length > maxBodySize) {
         res.statusCode = 413;
         res.end(
-          "This request was aborted by Aikido firewall because the body size exceeded the maximum allowed size. Use AIKIDO_MAX_BODY_SIZE_MB to increase the limit."
+          "This request was aborted by Aikido firewall because the body size exceeded the maximum allowed size. Use AIKIDO_MAX_BODY_SIZE_MB to increase the limit.",
+          () => {
+            req.destroy();
+          }
         );
         agent.getInspectionStatistics().onAbortedRequest();
 
@@ -44,7 +47,10 @@ export async function readBodyStream(
   } catch {
     res.statusCode = 500;
     res.end(
-      "Aikido firewall encountered an error while reading the request body."
+      "Aikido firewall encountered an error while reading the request body.",
+      () => {
+        req.destroy();
+      }
     );
 
     return {

--- a/library/sources/http-server/readBodyStream.ts
+++ b/library/sources/http-server/readBodyStream.ts
@@ -15,7 +15,7 @@ type BodyReadResult =
 
 export async function readBodyStream(
   req: IncomingMessage,
-  res: ServerResponse<IncomingMessage>,
+  res: ServerResponse,
   agent: Agent
 ): Promise<BodyReadResult> {
   let body = "";


### PR DESCRIPTION
To avoid sending a chunked response we cannot use `req.write(...)`

> Sends a chunk of the body. This method can be called multiple times. If no Content-Length is set, data will automatically be encoded in HTTP Chunked transfer encoding, so that server knows when the data ends. The Transfer-Encoding: chunked header is added. Calling request.end() is necessary to finish sending the request.

Instead call `req.end(...)` with the body. This will set `Content-length` automatically.