### PR TITLE
Fix Hono response body locked error

### DIFF
--- a/library/sources/Hono.test.ts
+++ b/library/sources/Hono.test.ts
@@ -94,6 +94,21 @@ function getApp() {
     return c.json(getContext());
   });
 
+  app.post("/json", async (c) => {
+    const json = await c.req.json();
+    return c.json(getContext());
+  });
+
+  app.post("/text", async (c) => {
+    const text = await c.req.text();
+    return c.json(getContext());
+  });
+
+  app.post("/form", async (c) => {
+    const form = await c.req.parseBody();
+    return c.json(getContext());
+  });
+
   app.on(["GET"], ["/user", "/user/blocked"], (c) => {
     return c.json(getContext());
   });
@@ -140,7 +155,7 @@ t.test("it adds context from request for GET", opts, async (t) => {
 });
 
 t.test("it adds JSON body to context", opts, async (t) => {
-  const response = await getApp().request("/", {
+  const response = await getApp().request("/json", {
     method: "POST",
     headers: {
       "content-type": "application/json",
@@ -153,12 +168,12 @@ t.test("it adds JSON body to context", opts, async (t) => {
     method: "POST",
     body: { title: "test" },
     source: "hono",
-    route: "/",
+    route: "/json",
   });
 });
 
 t.test("it adds form body to context", opts, async (t) => {
-  const response = await getApp().request("/", {
+  const response = await getApp().request("/form", {
     method: "POST",
     headers: {
       "content-type": "application/x-www-form-urlencoded",
@@ -171,12 +186,12 @@ t.test("it adds form body to context", opts, async (t) => {
     method: "POST",
     body: { title: "test" },
     source: "hono",
-    route: "/",
+    route: "/form",
   });
 });
 
 t.test("it adds text body to context", opts, async (t) => {
-  const response = await getApp().request("/", {
+  const response = await getApp().request("/text", {
     method: "POST",
     headers: {
       "content-type": "text/plain",
@@ -189,12 +204,12 @@ t.test("it adds text body to context", opts, async (t) => {
     method: "POST",
     body: "test",
     source: "hono",
-    route: "/",
+    route: "/text",
   });
 });
 
 t.test("it adds xml body to context", opts, async (t) => {
-  const response = await getApp().request("/", {
+  const response = await getApp().request("/text", {
     method: "POST",
     headers: {
       "content-type": "application/xml",
@@ -207,7 +222,7 @@ t.test("it adds xml body to context", opts, async (t) => {
     method: "POST",
     body: "<test>test</test>",
     source: "hono",
-    route: "/",
+    route: "/text",
   });
 });
 

--- a/library/sources/hono/contextFromRequest.ts
+++ b/library/sources/hono/contextFromRequest.ts
@@ -2,39 +2,11 @@ import type { Context as HonoContext } from "hono";
 import { Context } from "../../agent/Context";
 import { buildRouteFromURL } from "../../helpers/buildRouteFromURL";
 import { getIPAddressFromRequest } from "../../helpers/getIPAddressFromRequest";
-import { isJsonContentType } from "../../helpers/isJsonContentType";
 import { parse } from "../../helpers/parseCookies";
 import { getRemoteAddress } from "./getRemoteAddress";
 
 export async function contextFromRequest(c: HonoContext): Promise<Context> {
   const { req } = c;
-
-  let body = undefined;
-  const contentType = req.header("content-type");
-  if (contentType) {
-    if (isJsonContentType(contentType)) {
-      try {
-        body = await req.json();
-      } catch {
-        // Ignore
-      }
-    } else if (contentType.startsWith("application/x-www-form-urlencoded")) {
-      try {
-        body = await req.parseBody();
-      } catch {
-        // Ignore
-      }
-    } else if (
-      contentType.includes("text/plain") ||
-      contentType.includes("xml")
-    ) {
-      try {
-        body = await req.text();
-      } catch {
-        // Ignore
-      }
-    }
-  }
 
   const cookieHeader = req.header("cookie");
 
@@ -44,7 +16,7 @@ export async function contextFromRequest(c: HonoContext): Promise<Context> {
       headers: req.header(),
       remoteAddress: getRemoteAddress(c),
     }),
-    body: body,
+    body: undefined,
     url: req.url,
     headers: req.header(),
     routeParams: req.param(),

--- a/library/sources/hono/contextFromRequest.ts
+++ b/library/sources/hono/contextFromRequest.ts
@@ -16,7 +16,7 @@ export async function contextFromRequest(c: HonoContext): Promise<Context> {
       headers: req.header(),
       remoteAddress: getRemoteAddress(c),
     }),
-    body: undefined,
+    body: undefined, // Body is added in wrapRequestBodyParsing
     url: req.url,
     headers: req.header(),
     routeParams: req.param(),

--- a/library/sources/hono/contextFromRequest.ts
+++ b/library/sources/hono/contextFromRequest.ts
@@ -1,5 +1,5 @@
 import type { Context as HonoContext } from "hono";
-import { Context } from "../../agent/Context";
+import { Context, getContext } from "../../agent/Context";
 import { buildRouteFromURL } from "../../helpers/buildRouteFromURL";
 import { getIPAddressFromRequest } from "../../helpers/getIPAddressFromRequest";
 import { parse } from "../../helpers/parseCookies";
@@ -9,6 +9,7 @@ export async function contextFromRequest(c: HonoContext): Promise<Context> {
   const { req } = c;
 
   const cookieHeader = req.header("cookie");
+  const existingContext = getContext();
 
   return {
     method: c.req.method,
@@ -16,7 +17,11 @@ export async function contextFromRequest(c: HonoContext): Promise<Context> {
       headers: req.header(),
       remoteAddress: getRemoteAddress(c),
     }),
-    body: undefined, // Body is added in wrapRequestBodyParsing
+    // Pass the body from the existing context if it's already set, otherwise the body is set in wrapRequestBodyParsing
+    body:
+      existingContext && existingContext.source === "hono"
+        ? existingContext.body
+        : undefined,
     url: req.url,
     headers: req.header(),
     routeParams: req.param(),

--- a/library/sources/hono/wrapRequestBodyParsing.ts
+++ b/library/sources/hono/wrapRequestBodyParsing.ts
@@ -1,30 +1,33 @@
 import type { Context } from "hono";
 import { getContext, updateContext } from "../../agent/Context";
+import { createWrappedFunction, isWrapped } from "../../helpers/wrap";
 
+// Wrap the request body parsing functions to update the context with the parsed body, if any of the functions are called.
 export function wrapRequestBodyParsing(req: Context["req"]) {
-  req.parseBody = wrapRequestHandler(req.parseBody);
-  req.json = wrapRequestHandler(req.json);
-  req.text = wrapRequestHandler(req.text);
+  req.parseBody = wrapBodyParsingFunction(req.parseBody);
+  req.json = wrapBodyParsingFunction(req.json);
+  req.text = wrapBodyParsingFunction(req.text);
 }
 
-type BodyParseFunctions =
-  | Context["req"]["parseBody"]
-  | Context["req"]["json"]
-  | Context["req"]["text"];
+function wrapBodyParsingFunction<T extends Function>(func: T) {
+  if (isWrapped(func)) {
+    return func;
+  }
 
-function wrapRequestHandler<T extends BodyParseFunctions>(handler: T): T {
-  return async function parse() {
-    // @ts-expect-error No type for arguments
-    // eslint-disable-next-line prefer-rest-params
-    const returnValue = await handler.apply(this, arguments);
+  return createWrappedFunction(func, function parse(parser) {
+    return async function wrap() {
+      // @ts-expect-error No type for arguments
+      // eslint-disable-next-line prefer-rest-params
+      const returnValue = await parser.apply(this, arguments);
 
-    if (returnValue) {
-      const context = getContext();
-      if (context) {
-        updateContext(context, "body", returnValue);
+      if (returnValue) {
+        const context = getContext();
+        if (context) {
+          updateContext(context, "body", returnValue);
+        }
       }
-    }
 
-    return returnValue as ReturnType<T>;
-  } as T;
+      return returnValue;
+    };
+  }) as T;
 }

--- a/library/sources/hono/wrapRequestBodyParsing.ts
+++ b/library/sources/hono/wrapRequestBodyParsing.ts
@@ -1,0 +1,31 @@
+import type { Context } from "hono";
+import { getContext, updateContext } from "../../agent/Context";
+
+export function wrapRequestBodyParsing(req: Context["req"]) {
+  req.parseBody = wrapRequestHandler(req.parseBody);
+  req.json = wrapRequestHandler(req.json);
+  req.text = wrapRequestHandler(req.text);
+}
+
+type BodyParseFunctions =
+  | Context["req"]["parseBody"]
+  | Context["req"]["json"]
+  | Context["req"]["text"];
+
+export function wrapRequestHandler<T extends BodyParseFunctions>(
+  handler: T
+): T {
+  return async function () {
+    // @ts-expect-error No type for arguments
+    const returnValue = await handler.apply(this, arguments);
+
+    if (returnValue) {
+      const context = getContext();
+      if (context) {
+        updateContext(context, "body", returnValue);
+      }
+    }
+
+    return returnValue as ReturnType<T>;
+  } as T;
+}

--- a/library/sources/hono/wrapRequestBodyParsing.ts
+++ b/library/sources/hono/wrapRequestBodyParsing.ts
@@ -12,11 +12,10 @@ type BodyParseFunctions =
   | Context["req"]["json"]
   | Context["req"]["text"];
 
-export function wrapRequestHandler<T extends BodyParseFunctions>(
-  handler: T
-): T {
-  return async function () {
+function wrapRequestHandler<T extends BodyParseFunctions>(handler: T): T {
+  return async function parse() {
     // @ts-expect-error No type for arguments
+    // eslint-disable-next-line prefer-rest-params
     const returnValue = await handler.apply(this, arguments);
 
     if (returnValue) {

--- a/library/sources/hono/wrapRequestHandler.ts
+++ b/library/sources/hono/wrapRequestHandler.ts
@@ -1,6 +1,7 @@
 import type { Handler, MiddlewareHandler } from "hono";
 import { runWithContext } from "../../agent/Context";
 import { contextFromRequest } from "./contextFromRequest";
+import { wrapRequestBodyParsing } from "./wrapRequestBodyParsing";
 
 export function wrapRequestHandler(
   handler: Handler | MiddlewareHandler
@@ -9,6 +10,8 @@ export function wrapRequestHandler(
     const context = await contextFromRequest(c);
 
     return await runWithContext(context, async () => {
+      wrapRequestBodyParsing(c.req);
+
       return await handler(c, next);
     });
   };


### PR DESCRIPTION
```
TypeError: Response body object should not be disturbed or locked
at extractBody (node:internal/deps/undici/undici:5567:17)
at new Request (node:internal/deps/undici/undici:9783:48)
at new Request (/app/node_modules/@hono/node-server/dist/index.js:68:5)
at proxyRequest (/app/routes/api/oauth.js:42:5)
at /app/routes/api/oauth.js:69:20
at /app/node_modules/@aikidosec/firewall/sources/hono/wrapRequestHandler.js:10:26
at runWithContext (/app/node_modules/@aikidosec/firewall/agent/Context.js:56:16)
at /app/node_modules/@aikidosec/firewall/sources/hono/wrapRequestHandler.js:9:51
at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
at async dispatch (/app/node_modules/hono/dist/cjs/compose.js:52:17)
```

https://hono.dev/examples/proxy