### PR TITLE
Fix import with SyntheticDefaultImports enabled

### DIFF
--- a/library/index.ts
+++ b/library/index.ts
@@ -26,6 +26,8 @@ export {
   addKoaMiddleware,
 };
 
+// Required for ESM / TypeScript default export support
+// e.g. import Zen from '@aikidosec/firewall'; would not work without this, as Zen.setUser would be undefined
 export default {
   setUser,
   shouldBlockRequest,

--- a/library/index.ts
+++ b/library/index.ts
@@ -25,3 +25,13 @@ export {
   addFastifyHook,
   addKoaMiddleware,
 };
+
+export default {
+  setUser,
+  shouldBlockRequest,
+  addExpressMiddleware,
+  addHonoMiddleware,
+  addHapiMiddleware,
+  addFastifyHook,
+  addKoaMiddleware,
+};

--- a/sample-apps/nestjs-sentry/src/main.ts
+++ b/sample-apps/nestjs-sentry/src/main.ts
@@ -1,19 +1,19 @@
-import '@aikidosec/firewall';
-import * as Sentry from '@sentry/nestjs';
+import Zen from "@aikidosec/firewall";
+import * as Sentry from "@sentry/nestjs";
 
 Sentry.init({
-  dsn: 'https://examplePublicKey@o0.ingest.sentry.io/0',
+  dsn: "https://examplePublicKey@o0.ingest.sentry.io/0",
 });
 
-import { NestFactory } from '@nestjs/core';
-import { AppModule } from './app.module';
-import { ZenGuard } from './zen.guard';
+import { NestFactory } from "@nestjs/core";
+import { AppModule } from "./app.module";
+import { ZenGuard } from "./zen.guard";
 
 function getPort() {
   const port = parseInt(process.env.PORT, 10) || 4000;
 
   if (isNaN(port)) {
-    console.error('Invalid port');
+    console.error("Invalid port");
     process.exit(1);
   }
 
@@ -22,6 +22,8 @@ function getPort() {
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
+  Zen.addExpressMiddleware(app);
 
   app.useGlobalGuards(new ZenGuard());
   await app.listen(getPort());


### PR DESCRIPTION
In TypeScript you can write `import Zen from '@aikidosec/firewall';` instead of `import * as Zen from '@aikidosec/firewall';` if `allowSyntheticDefaultImports` is `true`.

This is also the case if `esModuleInterop` is set to `true` or if `moduleResolution` is set to `bundler`. See https://www.typescriptlang.org/tsconfig/#Interop_Constraints_6252 for more information.

But because we don't have a default export, at runtime you will get a crash like this:
```
import_firewall.default.addHonoMiddleware(app);
                        ^

TypeError: Cannot read properties of undefined (reading 'addHonoMiddleware')
```