### PR TITLE
Cleanup stack trace on require exceptions

### DIFF
--- a/library/agent/hooks/wrapRequire.test.ts
+++ b/library/agent/hooks/wrapRequire.test.ts
@@ -388,3 +388,13 @@ t.test(
     }
   }
 );
+
+t.test("cleans up stack trace if the module is not found", async (t) => {
+  const error = t.throws(() => require("unknown"));
+  t.ok(error instanceof Error);
+  if (error instanceof Error) {
+    t.match(error.message, /Cannot find module 'unknown'/);
+    t.match(error.stack, /node:internal\/modules/);
+    t.notMatch(error.stack, /Module\.patchedRequire/);
+  }
+});

--- a/library/agent/hooks/wrapRequire.ts
+++ b/library/agent/hooks/wrapRequire.ts
@@ -11,6 +11,7 @@ import type { PackageJson } from "type-fest";
 import { isMainJsFile } from "./isMainJsFile";
 import { WrapPackageInfo } from "./WrapPackageInfo";
 import { getInstance } from "../AgentSingleton";
+import { cleanError } from "../../helpers/cleanError";
 
 const originalRequire = mod.prototype.require;
 let isRequireWrapped = false;
@@ -47,6 +48,7 @@ export function wrapRequire() {
 
   // Wrap process.getBuiltinModule, which allows requiring builtin modules (since Node.js v22.3.0)
   if (typeof process.getBuiltinModule === "function") {
+    // @ts-expect-error We don't know what we return
     process.getBuiltinModule = function wrappedGetBuiltinModule() {
       // eslint-disable-next-line prefer-rest-params
       return patchedRequire.call(this, arguments);
@@ -78,11 +80,16 @@ export function setBuiltinModulesToPatch(
  * Our custom require function that intercepts require calls.
  */
 function patchedRequire(this: mod | NodeJS.Process, args: IArguments) {
-  // Apply the original require function
-  const originalExports = originalRequire.apply(
-    this,
-    args as unknown as [string]
-  );
+  let originalExports: unknown;
+  try {
+    // Apply the original require function
+    originalExports = originalRequire.apply(this, args as unknown as [string]);
+  } catch (err) {
+    if (!(err instanceof Error)) {
+      throw err;
+    }
+    throw cleanError(err);
+  }
 
   if (!args.length || typeof args[0] !== "string") {
     return originalExports;


### PR DESCRIPTION
*Before*:
```
Error: Cannot find module 't123'
Require stack:
- /Users/timokoessler/Git/firewall-node/sample-apps/express-mysql2/test.js
    at Function._resolveFilename (node:internal/modules/cjs/loader:1225:15)
    at Function._load (node:internal/modules/cjs/loader:1055:27)
    at TracingChannel.traceSync (node:diagnostics_channel:322:14)
    at wrapModuleLoad (node:internal/modules/cjs/loader:220:24)
    at Module.<anonymous> (node:internal/modules/cjs/loader:1311:12)
    at Module.patchedRequire (/Users/timokoessler/Git/firewall-node/build/agent/hooks/wrapRequire.js:74:43)
    at Module.wrapped [as require] (/Users/timokoessler/Git/firewall-node/build/agent/hooks/wrapRequire.js:39:31)
    at require (node:internal/modules/helpers:136:16)
    at Object.<anonymous> (test.js:1:1)
    at Module._compile (node:internal/modules/cjs/loader:1554:14)
```

*After*:
```
Error: Cannot find module 't123'
Require stack:
- /Users/timokoessler/Git/firewall-node/sample-apps/express-mysql2/test.js
    at Function._resolveFilename (node:internal/modules/cjs/loader:1225:15)
    at Function._load (node:internal/modules/cjs/loader:1055:27)
    at TracingChannel.traceSync (node:diagnostics_channel:322:14)
    at wrapModuleLoad (node:internal/modules/cjs/loader:220:24)
    at Module.<anonymous> (node:internal/modules/cjs/loader:1311:12)
    at require (node:internal/modules/helpers:136:16)
    at Object.<anonymous> (test.js:1:1)
    at Module._compile (node:internal/modules/cjs/loader:1554:14) 
```