### PR TITLE
Disable Function sink for now

### DIFF
--- a/benchmarks/operations/benchmark.js
+++ b/benchmarks/operations/benchmark.js
@@ -14,7 +14,9 @@ const modules = [
     module: "nosqli",
     name: "NoSQL query",
   },
-  /*{
+  /*
+  Disabled because functionName.constructor === Function is false after patching global
+  {
     module: "jsinjection",
     name: "`new Function(...)`",
   },*/

--- a/benchmarks/operations/benchmark.js
+++ b/benchmarks/operations/benchmark.js
@@ -14,10 +14,10 @@ const modules = [
     module: "nosqli",
     name: "NoSQL query",
   },
-  {
+  /*{
     module: "jsinjection",
     name: "`new Function(...)`",
-  },
+  },*/
   {
     module: "shelli",
     name: "Shell command",

--- a/end2end/tests/express-mongodb.code-injection.test.js
+++ b/end2end/tests/express-mongodb.code-injection.test.js
@@ -38,19 +38,25 @@ t.test("it blocks in blocking mode", (t) => {
   timeout(2000)
     .then(() => {
       return Promise.all([
-        fetch("http://127.0.0.1:4000/hello/hans", {
-          signal: AbortSignal.timeout(5000),
-        }),
-        fetch(`http://127.0.0.1:4000/hello/${encodeURIComponent(`hans" //`)}`, {
-          signal: AbortSignal.timeout(5000),
-        }),
+        fetch(
+          `http://127.0.0.1:4000/where?title=${encodeURIComponent("Test'||'a")}`,
+          {
+            signal: AbortSignal.timeout(5000),
+          }
+        ),
+        fetch(
+          `http://127.0.0.1:4000/where?title=${encodeURIComponent("Test' && sleep(10000); '")}`,
+          {
+            signal: AbortSignal.timeout(5000),
+          }
+        ),
       ]);
     })
-    .then(([safeName, unsafeName]) => {
-      t.equal(safeName.status, 200);
-      t.equal(unsafeName.status, 500);
+    .then(([req1, req2]) => {
+      t.equal(req1.status, 500);
+      t.equal(req2.status, 500);
       t.match(stdout, /Starting agent/);
-      t.match(stdout, /Zen has blocked a JavaScript injection/);
+      t.match(stdout, /Zen has blocked a NoSQL injection/);
     })
     .catch((error) => {
       t.fail(error);
@@ -83,19 +89,25 @@ t.test("it does not block in dry mode", (t) => {
   timeout(2000)
     .then(() =>
       Promise.all([
-        fetch("http://127.0.0.1:4001/hello/hans", {
-          signal: AbortSignal.timeout(5000),
-        }),
-        fetch(`http://127.0.0.1:4001/hello/${encodeURIComponent(`hans" //`)}`, {
-          signal: AbortSignal.timeout(5000),
-        }),
+        fetch(
+          `http://127.0.0.1:4001/where?title=${encodeURIComponent("Test'||'a")}`,
+          {
+            signal: AbortSignal.timeout(5000),
+          }
+        ),
+        fetch(
+          `http://127.0.0.1:4001/where?title=${encodeURIComponent("Test' && sleep(10000); '")}`,
+          {
+            signal: AbortSignal.timeout(5000),
+          }
+        ),
       ])
     )
-    .then(([safeName, unsafeName]) => {
-      t.equal(safeName.status, 200);
-      t.equal(unsafeName.status, 200);
+    .then(([req1, req2]) => {
+      t.equal(req1.status, 200);
+      t.equal(req2.status, 200);
       t.match(stdout, /Starting agent/);
-      t.match(stdout, /Zen has detected a JavaScript injection/);
+      t.match(stdout, /Zen has detected a NoSQL injection/);
     })
     .catch((error) => {
       t.fail(error);

--- a/library/agent/protect.ts
+++ b/library/agent/protect.ts
@@ -141,7 +141,7 @@ export function getWrappers() {
     new Koa(),
     new ClickHouse(),
     new Prisma(),
-    new Function(),
+    // new Function(), Disabled because functionName.constructor === Function is false after patching global
   ];
 }
 

--- a/library/agent/protect.ts
+++ b/library/agent/protect.ts
@@ -48,7 +48,6 @@ import { Fastify } from "../sources/Fastify";
 import { Koa } from "../sources/Koa";
 import { ClickHouse } from "../sinks/ClickHouse";
 import { Prisma } from "../sinks/Prisma";
-import { Function } from "../sinks/Function";
 
 function getLogger(): Logger {
   if (isDebugging()) {


### PR DESCRIPTION
Because of monkey-patching a global the following is no longer working:

```js
const test = function() {};

test.constructor === Function // Not true if Zen is imported

```