### PR TITLE
Fix absolute path traversal bypass with backslash conversion

### DIFF
--- a/library/vulnerabilities/path-traversal/containsUnsafePathParts.ts
+++ b/library/vulnerabilities/path-traversal/containsUnsafePathParts.ts
@@ -1,3 +1,5 @@
+import { normalizeLikeURLConstructor } from "./normalizeLikeURLConstructor";
+
 const dangerousPathParts = ["../", "..\\"];
 
 export function containsUnsafePathParts(filePath: string) {
@@ -10,16 +12,6 @@ export function containsUnsafePathParts(filePath: string) {
   return false;
 }
 
-/**
- * This function is used for urls, because they can contain a TAB, carriage return or line feed that is silently removed by the URL constructor.
- *
- * The WHATWG URL spec defines the following:
- * - Remove all ASCII tab or newline from input.
- * - An ASCII tab or newline is U+0009 TAB, U+000A LF, or U+000D CR.
- *
- * See https://url.spec.whatwg.org/#url-parsing
- */
 export function containsUnsafePathPartsUrl(filePath: string) {
-  const normalized = filePath.replace(/[\t\n\r]/g, "");
-  return containsUnsafePathParts(normalized);
+  return containsUnsafePathParts(normalizeLikeURLConstructor(filePath));
 }

--- a/library/vulnerabilities/path-traversal/detectPathTraversal.ts
+++ b/library/vulnerabilities/path-traversal/detectPathTraversal.ts
@@ -2,7 +2,10 @@ import {
   containsUnsafePathParts,
   containsUnsafePathPartsUrl,
 } from "./containsUnsafePathParts";
-import { startsWithUnsafePath } from "./unsafePathStart";
+import {
+  startsWithUnsafePath,
+  startsWithUnsafePathUrl,
+} from "./unsafePathStart";
 import { fileURLToPath } from "url";
 
 export function detectPathTraversal(
@@ -19,13 +22,18 @@ export function detectPathTraversal(
   // Check for URL path traversal
   // Reason: new URL("file:///../../test.txt") => /test.txt
   // The normal check for relative path traversal will fail in this case, because transformed path does not contain ../.
-  // For absolute path traversal, we dont need to check the transformed path, because it will always start with /.
   // Also /./ is checked by normal absolute path traversal check (if #219 is merged)
   // Use containsUnsafePathPartsUrl, because urls can contain a TAB, carriage return or line feed that is silently removed by the URL constructor.
-  if (isUrl && containsUnsafePathPartsUrl(userInput)) {
-    const filePathFromUrl = parseAsFileUrl(userInput);
-    if (filePathFromUrl && filePath.includes(filePathFromUrl)) {
-      return true;
+  // Use startsWithUnsafePathUrl, because URLs can contain backward slashes that are converted to forward slashes by the URL constructor.
+  if (isUrl) {
+    const containsUnsafePath = containsUnsafePathPartsUrl(userInput);
+    const startWithUnsafePath = startsWithUnsafePathUrl(filePath, userInput);
+
+    if (containsUnsafePath || startWithUnsafePath) {
+      const filePathFromUrl = parseAsFileUrl(userInput);
+      if (filePathFromUrl && filePath.includes(filePathFromUrl)) {
+        return true;
+      }
     }
   }
 
@@ -63,7 +71,7 @@ export function detectPathTraversal(
 function parseAsFileUrl(path: string) {
   let url = path;
   if (!url.startsWith("file:")) {
-    if (!url.startsWith("/")) {
+    if (!url.startsWith("/") && !url.startsWith("\\")) {
       url = `/${url}`;
     }
     url = `file://${url}`;

--- a/library/vulnerabilities/path-traversal/normalizeLikeURLConstructor.ts
+++ b/library/vulnerabilities/path-traversal/normalizeLikeURLConstructor.ts
@@ -1,0 +1,14 @@
+/**
+ * This function is used for urls, because they can contain a TAB, carriage return or line feed that is silently removed by the URL constructor.
+ *
+ * The WHATWG URL spec defines the following:
+ * - Remove all ASCII tab or newline from input.
+ * - An ASCII tab or newline is U+0009 TAB, U+000A LF, or U+000D CR.
+ *
+ * Also, backward slashes are converted to forward slashes by the URL constructor.
+ *
+ * See https://url.spec.whatwg.org/#url-parsing
+ */
+export function normalizeLikeURLConstructor(url: string): string {
+  return url.replace(/[\t\n\r]/g, "").replace(/\\/g, "/");
+}

--- a/library/vulnerabilities/path-traversal/unsafePathStart.ts
+++ b/library/vulnerabilities/path-traversal/unsafePathStart.ts
@@ -1,5 +1,6 @@
 import { isAbsolute, resolve } from "path";
 import { isWrapped } from "../../helpers/wrap";
+import { normalizeLikeURLConstructor } from "./normalizeLikeURLConstructor";
 
 const linuxRootFolders = [
   "/bin/",
@@ -56,4 +57,8 @@ export function startsWithUnsafePath(filePath: string, userInput: string) {
     }
   }
   return false;
+}
+
+export function startsWithUnsafePathUrl(filePath: string, userInput: string) {
+  return startsWithUnsafePath(filePath, normalizeLikeURLConstructor(userInput));
 }


### PR DESCRIPTION
I also found out we didn't check \t \r \n for absolute paths (if it's an URL object)