### PR TITLE
Don't send heartbeat when there are compressed stats

### DIFF
--- a/library/agent/Agent.ts
+++ b/library/agent/Agent.ts
@@ -352,12 +352,10 @@ export class Agent {
       const now = performance.now();
       const diff = now - this.lastHeartbeat;
       const shouldSendHeartbeat = diff > this.sendHeartbeatEveryMS;
-      const hasCompressedStats = this.statistics.hasCompressedStats();
       const canSendInitialStats =
         !this.serviceConfig.hasReceivedAnyStats() && !this.statistics.isEmpty();
       const shouldReportInitialStats =
-        !this.reportedInitialStats &&
-        (hasCompressedStats || canSendInitialStats);
+        !this.reportedInitialStats && canSendInitialStats;
 
       if (shouldSendHeartbeat || shouldReportInitialStats) {
         this.heartbeat();


### PR DESCRIPTION
We keep durations per operation (to measure the time our algo takes to detect attacks)

After 5000 samples we compress them into percentiles. 5000 invocations is not much. This means that we will send a heartbeat almost every checkIfHeartbeatIsNeededEveryMS for normal production traffic

Which is currently set at 60s

So every minute we would send a heartbeat...