### PR TITLE
Reduce compressed stats per operation from 100 -> 20

### DIFF
--- a/library/agent/Agent.ts
+++ b/library/agent/Agent.ts
@@ -54,7 +54,7 @@ export class Agent {
   private rateLimiter: RateLimiter = new RateLimiter(5000, 120 * 60 * 1000);
   private statistics = new InspectionStatistics({
     maxPerfSamplesInMemory: 5000,
-    maxCompressedStatsInMemory: 100,
+    maxCompressedStatsInMemory: 20, // per operation
   });
   private middlewareInstalled = false;
   private attackLogger = new AttackLogger(1000);


### PR DESCRIPTION
We keep durations of invocations to measure how long our algo takes to detect attacks. So per `fs.readFile` or `mysql.query`...

When 5000 samples are reached, we compress the durations into percentiles.

100 * 5000 = 5M durations

That's a lot per operation. I think we can reduce this to 100K invocations per operation :)

So that we only keep 20 compressed percentiles per operation.

If we go over this 20, we drop the oldest compressed percentiles.