### PR TITLE
Add missing apispec property type for routes

### DIFF
--- a/library/agent/api/Event.ts
+++ b/library/agent/api/Event.ts
@@ -1,3 +1,4 @@
+import { APISpec } from "../api-discovery/getApiInfo";
 import { Kind } from "../Attack";
 import { Source } from "../Source";
 
@@ -117,6 +118,7 @@ type Heartbeat = {
     method: string;
     hits: number;
     graphql?: { type: "query" | "mutation"; name: string };
+    apispec: APISpec;
   }[];
   users: {
     id: string;


### PR DESCRIPTION
Additional properties don't throw errors in TypeScript, if the type shape matches, it's fine for TypeScript.

There's a proposal for exact types: https://github.com/microsoft/TypeScript/issues/12936

Some people suggested this utility type:

```ts
type Exact<A, B> = A extends B ? (B extends A ? A : never) : never;
```

But I find it a bit cumbersome: `Exact<Event, Event>`

So I left it out.