### PR TITLE
Remove unused eslint-disable comments

### DIFF
--- a/library/sinks/ChildProcess.ts
+++ b/library/sinks/ChildProcess.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines-per-function */
 import { getContext } from "../agent/Context";
 import { Hooks } from "../agent/hooks/Hooks";
 import { InterceptorResult } from "../agent/hooks/InterceptorResult";

--- a/library/sinks/FileSystem.ts
+++ b/library/sinks/FileSystem.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines-per-function */
 import { getContext } from "../agent/Context";
 import { Hooks } from "../agent/hooks/Hooks";
 import { InterceptorResult } from "../agent/hooks/InterceptorResult";

--- a/library/sources/Fastify.ts
+++ b/library/sources/Fastify.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines-per-function */
 import type { RouteOptions } from "fastify";
 import { Hooks } from "../agent/hooks/Hooks";
 import { Wrapper } from "../agent/Wrapper";

--- a/library/sources/HTTPServer.ts
+++ b/library/sources/HTTPServer.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines-per-function */
 import { Agent } from "../agent/Agent";
 import { Hooks } from "../agent/hooks/Hooks";
 import { wrapExport } from "../agent/hooks/wrapExport";


### PR DESCRIPTION
```
/home/runner/work/firewall-node/firewall-node/library/sinks/ChildProcess.ts
  1:1  warning  Unused eslint-disable directive (no problems were reported from 'max-lines-per-function')

/home/runner/work/firewall-node/firewall-node/library/sinks/FileSystem.ts
  1:1  warning  Unused eslint-disable directive (no problems were reported from 'max-lines-per-function')

/home/runner/work/firewall-node/firewall-node/library/sources/Fastify.ts
  1:1  warning  Unused eslint-disable directive (no problems were reported from 'max-lines-per-function')

/home/runner/work/firewall-node/firewall-node/library/sources/HTTPServer.ts
  1:1  warning  Unused eslint-disable directive (no problems were reported from 'max-lines-per-function')

✖ 4 problems (0 errors, 4 warnings)
  0 errors and 4 warnings potentially fixable with the `--fix` option.
```