### PR TITLE
Ignore alphanumerical payloads ending with =

### DIFF
--- a/library/vulnerabilities/sql-injection/detectSQLInjection.test.ts
+++ b/library/vulnerabilities/sql-injection/detectSQLInjection.test.ts
@@ -29,6 +29,13 @@ t.test("It allows escape sequences", async (t) => {
   isNotSqlInjection("SELECT * FROM users WHERE id = '\tusers'", "\tusers");
 });
 
+t.test("It does not flag short operator patterns as injections", async () => {
+  isNotSqlInjection(
+    "select column form table where table.a = 1 AND table.active= 1",
+    "e="
+  );
+});
+
 t.test("user input inside IN (...)", async () => {
   isNotSqlInjection("SELECT * FROM users WHERE id IN ('123')", "'123'");
   isNotSqlInjection("SELECT * FROM users WHERE id IN (123)", "123");

--- a/library/vulnerabilities/sql-injection/shouldReturnEarly.test.ts
+++ b/library/vulnerabilities/sql-injection/shouldReturnEarly.test.ts
@@ -57,4 +57,13 @@ t.test("should return early - false cases", async (t) => {
     shouldReturnEarly("SELECT * FROM users; DROP TABLE", "users; DROP TABLE"),
     false
   );
+
+  // Specific test for the "e=" false positive case
+  t.equal(
+    shouldReturnEarly(
+      "select column form table where table.a = 1 AND table.active= 1",
+      "e="
+    ),
+    true
+  );
 });

--- a/library/vulnerabilities/sql-injection/shouldReturnEarly.ts
+++ b/library/vulnerabilities/sql-injection/shouldReturnEarly.ts
@@ -18,11 +18,6 @@ export function shouldReturnEarly(query: string, userInput: string) {
     return true;
   }
 
-  // Short operator-ending patterns are safe (e.g., "e=")
-  if (userInputLowercase.length == 2 && /^[a-z]=$/i.test(userInputLowercase)) {
-    return true;
-  }
-
   // Check if user input is a valid comma-separated list of numbers
   const cleanedInputForList = userInputLowercase
     .replace(/ /g, "")

--- a/library/vulnerabilities/sql-injection/shouldReturnEarly.ts
+++ b/library/vulnerabilities/sql-injection/shouldReturnEarly.ts
@@ -19,7 +19,7 @@ export function shouldReturnEarly(query: string, userInput: string) {
   }
 
   // Short operator-ending patterns are safe (e.g., "e=")
-  if (userInputLowercase.length <= 2 && /^[a-z=]+$/i.test(userInputLowercase)) {
+  if (userInputLowercase.length == 2 && /^[a-z]=$/i.test(userInputLowercase)) {
     return true;
   }
 

--- a/library/vulnerabilities/sql-injection/shouldReturnEarly.ts
+++ b/library/vulnerabilities/sql-injection/shouldReturnEarly.ts
@@ -18,6 +18,11 @@ export function shouldReturnEarly(query: string, userInput: string) {
     return true;
   }
 
+  // Short operator-ending patterns are safe (e.g., "e=")
+  if (userInputLowercase.length <= 2 && /^[a-z=]+$/i.test(userInputLowercase)) {
+    return true;
+  }
+
   // Check if user input is a valid comma-separated list of numbers
   const cleanedInputForList = userInputLowercase
     .replace(/ /g, "")


### PR DESCRIPTION
query
```sql
SELECT * FROM table WHERE table.active= 1
```

payload
```e=```

will alter the token structure after replacing with safe string "aa":
```sql
SELECT * FROM table WHERE table.activaa 1
```

So it will be flagged as a SQL injection, in general just using `e=` as payload will be very difficult to exploit. (as the generated SQL query should still be valid)

Waiting for https://github.com/AikidoSec/zen-internals/pull/90