### PR TITLE
Set original function in `__NR_original` property

### DIFF
--- a/library/helpers/wrap.ts
+++ b/library/helpers/wrap.ts
@@ -32,6 +32,7 @@ export function createWrappedFunction(
   const wrapped = wrapper(original);
 
   defineProperty(wrapped, "__original", original);
+  defineProperty(wrapped, "__NR_original", original);
   defineProperty(wrapped, "__wrapped", true);
 
   // Copy over all properties from the original function to the wrapped one.


### PR DESCRIPTION
This ensures that loopback framework can find it back:

```js
/*!
 * Find the corresponding express layer by handler *
 * This is needed because monitoring agents such as NewRelic can add handlers
 * to the stack. For example, NewRelic adds sentinel handler. We need to search
 * the stackto find the correct layer. */ proto._findLayerByHandler = function(handler) {
  // Other handlers can be added to the stack, for example,
  // NewRelic adds sentinel handler, and AppDynamics adds
  // some additional proxy info. We need to search the stack
  for (let k = this._router.stack.length - 1; k >= 0; k--) {
    const isOriginal = this._router.stack[k].handle === handler;
    const isNewRelic = this._router.stack[k].handle['__NR_original'] === handler;
    const isAppDynamics = this._router.stack[k].handle['__appdynamicsProxyInfo__'] &&
      this._router.stack[k].handle['__appdynamicsProxyInfo__']['orig'] === handler;
```

`this._router.stack[k].handle === handler` doesn't work since we wrap the functions and that changes the identity.