### PR TITLE
Fix https-proxy-agent compatibility with URL objects

### DIFF
--- a/library/helpers/fetch.test.ts
+++ b/library/helpers/fetch.test.ts
@@ -130,3 +130,29 @@ t.test("should make a POST request with body and gzip", async (t) => {
     },
   });
 });
+
+t.test(
+  "should convert URL object to string for http.request compatibility",
+  async (t) => {
+    const http = require("http");
+    const originalRequest = http.request;
+    let receivedUrl: unknown;
+
+    // Mock the http.request to verify it receives a string URL
+    http.request = (url: unknown, options: unknown, callback: unknown) => {
+      receivedUrl = url;
+      return originalRequest(url, options, callback);
+    };
+
+    try {
+      const url = new URL(`http://localhost:${(server.address() as any).port}`);
+      await fetch({ url });
+
+      t.equal(typeof receivedUrl, "string");
+      t.equal(receivedUrl, url.toString());
+    } finally {
+      // Restore original request!
+      http.request = originalRequest;
+    }
+  }
+);

--- a/library/helpers/fetch.ts
+++ b/library/helpers/fetch.ts
@@ -21,7 +21,7 @@ function request({
   return new Promise((resolve, reject) => {
     // Convert URL object to string for compatibility with old https-proxy-agent versions
     // Old agent-base library (used by https-proxy-agent) only works with string URLs
-    // and fails when passed URL objects, causing requests to fallback to 127.0.0.1:443
+    // and fails when passed URL objects, causing communication with our dashboard to fail
     const req = request(
       url.toString(),
       {

--- a/library/helpers/fetch.ts
+++ b/library/helpers/fetch.ts
@@ -19,8 +19,11 @@ function request({
   const request = url.protocol === "https:" ? requestHttps : requestHttp;
 
   return new Promise((resolve, reject) => {
+    // Convert URL object to string for compatibility with old https-proxy-agent versions
+    // Old agent-base library (used by https-proxy-agent) only works with string URLs
+    // and fails when passed URL objects, causing requests to fallback to 127.0.0.1:443
     const req = request(
-      url,
+      url.toString(),
       {
         method,
         headers,


### PR DESCRIPTION
Old `https-proxy-agent` versions fail when `http.request()` receives URL objects instead of strings, causing requests to fallback to `127.0.0.1:443`.

Convert URL objects to strings before passing to `http.request()`.