### PR TITLE
Decrease min percentage diff for ip list benchmark

### DIFF
--- a/library/helpers/ip-matcher/performance.test.ts
+++ b/library/helpers/ip-matcher/performance.test.ts
@@ -811,5 +811,5 @@ t.test("test performance in comparison to node:net.blocklist", async (t) => {
   const percentageDiff = ((blockListMs - ipMatcherMs) / ipMatcherMs) * 100;
 
   // Expect the IPMatcher to be faster than the BlockList
-  t.same(percentageDiff > 25, true);
+  t.same(percentageDiff > 20, true);
 });

--- a/library/helpers/ip-matcher/performance.test.ts
+++ b/library/helpers/ip-matcher/performance.test.ts
@@ -811,5 +811,5 @@ t.test("test performance in comparison to node:net.blocklist", async (t) => {
   const percentageDiff = ((blockListMs - ipMatcherMs) / ipMatcherMs) * 100;
 
   // Expect the IPMatcher to be faster than the BlockList
-  t.same(percentageDiff > 20, true);
+  t.same(percentageDiff > 10, true);
 });


### PR DESCRIPTION
Locally on macOS it is over 160% faster, but often fails in Github Actions