### PR TITLE
Port ESM unit test changes to main branch

### DIFF
--- a/library/agent/api-discovery/getDataSchema.test.ts
+++ b/library/agent/api-discovery/getDataSchema.test.ts
@@ -94,7 +94,7 @@ t.test("it works", async (t) => {
         },
         arr: {
           type: "array",
-          items: undefined,
+          items: null,
         },
       },
     }

--- a/library/agent/api-discovery/mergeDataSchemas.test.ts
+++ b/library/agent/api-discovery/mergeDataSchemas.test.ts
@@ -114,7 +114,7 @@ t.test("it prefers non-null type", async (t) => {
 t.test("empty array", async (t) => {
   t.same(mergeDataSchemas(getDataSchema([]), getDataSchema([])), {
     type: "array",
-    items: undefined,
+    items: null,
   });
 });
 

--- a/library/agent/hooks/wrapExport.test.ts
+++ b/library/agent/hooks/wrapExport.test.ts
@@ -33,7 +33,7 @@ createTestAgent({
 });
 
 t.test("Inspect args", async (t) => {
-  t.plan(2);
+  let executedCallback = false;
   const toWrap = {
     test(input: string) {
       return input;
@@ -47,12 +47,14 @@ t.test("Inspect args", async (t) => {
     {
       kind: "outgoing_http_op",
       inspectArgs: (args) => {
+        executedCallback = true;
         t.same(args, ["input"]);
       },
     }
   );
 
   t.same(toWrap.test("input"), "input");
+  t.ok(executedCallback);
 });
 
 t.test("Modify args", async (t) => {
@@ -202,7 +204,7 @@ t.test("Wrap non existing method", async (t) => {
 });
 
 t.test("Wrap default export", async (t) => {
-  t.plan(2);
+  let executedCallback = false;
   const toWrap = (input: string) => {
     return input;
   };
@@ -214,10 +216,12 @@ t.test("Wrap default export", async (t) => {
     {
       kind: "outgoing_http_op",
       inspectArgs: (args) => {
+        executedCallback = true;
         t.same(args, ["input"]);
       },
     }
   ) as Function;
 
   t.same(patched("input"), "input");
+  t.ok(executedCallback);
 });

--- a/library/sinks/ChildProcess.test.ts
+++ b/library/sinks/ChildProcess.test.ts
@@ -1,8 +1,8 @@
 import * as t from "tap";
 import { Context, runWithContext } from "../agent/Context";
 import { ChildProcess } from "./ChildProcess";
-import { execFile, execFileSync } from "child_process";
 import { createTestAgent } from "../helpers/createTestAgent";
+import { join } from "path";
 
 const unsafeContext: Context = {
   remoteAddress: "::1",
@@ -35,7 +35,7 @@ t.test("it works", async (t) => {
 
   agent.start([new ChildProcess()]);
 
-  const { exec, execSync, spawn, spawnSync, fork } =
+  const { exec, execSync, spawn, spawnSync, fork, execFile, execFileSync } =
     require("child_process") as typeof import("child_process");
 
   const runCommandsWithInvalidArgs = () => {
@@ -83,7 +83,7 @@ t.test("it works", async (t) => {
     execFile("ls", ["-la"], {}, (err, stdout, stderr) => {}).unref();
     execFileSync("ls", ["-la"], {});
 
-    fork("./fixtures/helloWorld.js").unref();
+    fork(join(__dirname, "./fixtures/helloWorld.js")).unref();
   };
 
   runSafeCommands();

--- a/library/sinks/ClickHouse.test.ts
+++ b/library/sinks/ClickHouse.test.ts
@@ -69,14 +69,14 @@ t.test("it detects SQL injections", async (t) => {
       format: "JSONEachRow",
     });
 
-    t.same(await resultSet.json(), [{ id: 1, petname: "Felix" }]);
+    t.same(await resultSet.json(), [{ id: "1", petname: "Felix" }]);
 
     await runWithContext(safeContext, async () => {
       const resultSet = await client.query({
         query: `SELECT * FROM cats;`,
         format: "JSONEachRow",
       });
-      t.same(await resultSet.json(), [{ id: 1, petname: "Felix" }]);
+      t.same(await resultSet.json(), [{ id: "1", petname: "Felix" }]);
     });
 
     await runWithContext(dangerousContext, async () => {

--- a/library/sinks/Fetch.test.ts
+++ b/library/sinks/Fetch.test.ts
@@ -148,7 +148,7 @@ t.test(
       t.same(events.length, 1);
       t.same(events[0].attack.metadata, {
         hostname: "localhost",
-        port: 4000,
+        port: "4000",
       });
 
       const error2 = await t.rejects(() =>

--- a/library/sinks/HTTPRequest.localhost.test.ts
+++ b/library/sinks/HTTPRequest.localhost.test.ts
@@ -54,6 +54,8 @@ const agent = createTestAgent({
 
 agent.start([new HTTPRequest()]);
 
+const http = require("http");
+
 const port = 1343;
 const serverUrl = `http://localhost:${port}`;
 const hostHeader = `localhost:${port}`;
@@ -72,8 +74,6 @@ t.before(async () => {
 });
 
 t.test("it does not block request to localhost with same port", (t) => {
-  const http = require("http");
-
   runWithContext(
     createContext({
       url: serverUrl,
@@ -107,8 +107,6 @@ t.test("it does not block request to localhost with same port", (t) => {
 });
 
 t.test("it blocks requests to other ports", (t) => {
-  const http = require("http");
-
   runWithContext(
     createContext({
       url: `http://localhost:${port + 1}`,

--- a/library/sinks/HTTPRequest.test.ts
+++ b/library/sinks/HTTPRequest.test.ts
@@ -133,7 +133,7 @@ t.test("it works", (t) => {
   t.same(withStringPort instanceof http.ClientRequest, true);
   withStringPort.end();
   t.same(agent.getHostnames().asArray(), [
-    { hostname: "aikido.dev", port: "443", hits: 1 },
+    { hostname: "aikido.dev", port: 443, hits: 1 },
   ]);
   agent.getHostnames().clear();
 

--- a/library/sinks/http-request/getUrlFromHTTPRequestArgs.test.ts
+++ b/library/sinks/http-request/getUrlFromHTTPRequestArgs.test.ts
@@ -79,7 +79,6 @@ t.test("it does not throw on invalid arguments", async (t) => {
   t.same(getURL([], "http"), undefined);
   // @ts-expect-error Test
   t.same(getURL(["%test%"], undefined), undefined);
-  t.same(new Date(), []);
 });
 
 t.test("it works without url and only options", async (t) => {

--- a/library/sources/Restify.v11.test.ts
+++ b/library/sources/Restify.v11.test.ts
@@ -7,7 +7,7 @@ t.test(
   {
     skip:
       getMajorNodeVersion() > 18
-        ? "Restify v10 only supports node v18 and lower"
+        ? "Restify v11 only supports node v18 and lower"
         : undefined,
   },
   async () => {

--- a/library/sources/Restify.v9.test.ts
+++ b/library/sources/Restify.v9.test.ts
@@ -7,7 +7,7 @@ t.test(
   {
     skip:
       getMajorNodeVersion() > 16
-        ? "Restify v8 only supports node v16"
+        ? "Restify v9 only supports node v16"
         : undefined,
   },
   async () => {

--- a/library/sources/XmlMinusJs.test.ts
+++ b/library/sources/XmlMinusJs.test.ts
@@ -10,13 +10,15 @@ agent.start([new XmlMinusJs()]);
 
 const xmljs = require("xml-js");
 
-t.test("xml2js works", async () => {
+t.test("xml-js works", async () => {
   const xmlString = (
     await readFile(join(__dirname, "fixtures", "products.xml"), "utf8")
   ).toString();
 
   const result = xmljs.xml2js(xmlString);
-  const expected = require(join(__dirname, "fixtures", "xml2js.json"));
+  const expected = JSON.parse(
+    await readFile(join(__dirname, "fixtures", "xml2js.json"), "utf8")
+  );
   t.same(result, expected);
 
   const context = {
@@ -32,8 +34,8 @@ t.test("xml2js works", async () => {
     route: "/posts/:id",
   };
 
-  const expectedCompact = require(
-    join(__dirname, "fixtures", "xml2js.compact.json")
+  const expectedCompact = JSON.parse(
+    await readFile(join(__dirname, "fixtures", "xml2js.compact.json"), "utf8")
   );
 
   runWithContext(context, () => {

--- a/library/vulnerabilities/sql-injection/detectSQLInjection.mysql.test.ts
+++ b/library/vulnerabilities/sql-injection/detectSQLInjection.mysql.test.ts
@@ -82,9 +82,9 @@ t.test("It flags SET CHARACTER SET as SQL injection", async () => {
 });
 
 function isSqlInjection(sql: string, input: string) {
-  t.same(detectSQLInjection(sql, input, new SQLDialectMySQL()), true, sql);
+  t.same(detectSQLInjection(sql, input, new SQLDialectMySQL()), 1, sql);
 }
 
 function isNotSQLInjection(sql: string, input: string) {
-  t.same(detectSQLInjection(sql, input, new SQLDialectMySQL()), false, sql);
+  t.same(detectSQLInjection(sql, input, new SQLDialectMySQL()), 0, sql);
 }

--- a/library/vulnerabilities/sql-injection/detectSQLInjection.postgres.test.ts
+++ b/library/vulnerabilities/sql-injection/detectSQLInjection.postgres.test.ts
@@ -57,9 +57,9 @@ t.test("It flags CLIENT_ENCODING as SQL injection", async () => {
 });
 
 function isSqlInjection(sql: string, input: string) {
-  t.same(detectSQLInjection(sql, input, new SQLDialectPostgres()), true, sql);
+  t.same(detectSQLInjection(sql, input, new SQLDialectPostgres()), 1, sql);
 }
 
 function isNotSQLInjection(sql: string, input: string) {
-  t.same(detectSQLInjection(sql, input, new SQLDialectPostgres()), false, sql);
+  t.same(detectSQLInjection(sql, input, new SQLDialectPostgres()), 0, sql);
 }

--- a/library/vulnerabilities/sql-injection/detectSQLInjection.sqlite.test.ts
+++ b/library/vulnerabilities/sql-injection/detectSQLInjection.sqlite.test.ts
@@ -31,9 +31,9 @@ t.test("$$ is treated as placeholder", async () => {
 });
 
 function isSqlInjection(sql: string, input: string) {
-  t.same(detectSQLInjection(sql, input, new SQLDialectSQLite()), true, sql);
+  t.same(detectSQLInjection(sql, input, new SQLDialectSQLite()), 1, sql);
 }
 
 function isNotSQLInjection(sql: string, input: string) {
-  t.same(detectSQLInjection(sql, input, new SQLDialectSQLite()), false, sql);
+  t.same(detectSQLInjection(sql, input, new SQLDialectSQLite()), 0, sql);
 }

--- a/library/vulnerabilities/sql-injection/detectSQLInjection.test.ts
+++ b/library/vulnerabilities/sql-injection/detectSQLInjection.test.ts
@@ -334,7 +334,7 @@ for (const file of files) {
             sql,
             new SQLDialectMySQL()
           ),
-          false,
+          0,
           `${sql} (mysql)`
         );
       }
@@ -350,7 +350,7 @@ for (const file of files) {
             sql,
             new SQLDialectMySQL()
           ),
-          false,
+          0,
           `${sql} (mysql)`
         );
       }

--- a/library/vulnerabilities/ssrf/inspectDNSLookupCalls.test.ts
+++ b/library/vulnerabilities/ssrf/inspectDNSLookupCalls.test.ts
@@ -103,7 +103,6 @@ t.test("it blocks lookup in blocking mode", (t) => {
             kind: "ssrf",
             metadata: {
               hostname: "localhost",
-              port: undefined,
             },
           },
         },


### PR DESCRIPTION
For running our unit tests in ESM mode we convert the tap calls to the builtin test runner assertions, tap isn't as strict as the builtin assertions. So let's do some cleanup so that the diff isn't as big.