### PR TITLE
Remove restart from sample db containers

### DIFF
--- a/sample-apps/docker-compose.yml
+++ b/sample-apps/docker-compose.yml
@@ -7,7 +7,6 @@ services:
       - "9090:9090"
   mongodb:
     image: mongo:5
-    restart: always
     volumes:
       - mongodb:/data/db
     environment:
@@ -17,7 +16,6 @@ services:
       - "27017:27017"
   postgres:
     image: postgres:14-alpine
-    restart: always
     volumes:
       - postgres:/var/lib/postgresql/data
     environment:


### PR DESCRIPTION
It's confusing that some containers restart automatically, but most don't.