### PR TITLE
Increase iterations for SQL injection benchmark

### DIFF
--- a/benchmarks/sql-injection/benchmark.js
+++ b/benchmarks/sql-injection/benchmark.js
@@ -56,7 +56,7 @@ function getAvgBenchmark() {
     sqlite: new SQLDialectSQLite(),
   };
   let avgTime = 0;
-  let amount = 1000;
+  let amount = 100_000;
   for (let i = 0; i < amount; i++) {
     const sql = randomEntry(sqlQueries);
     const input = randomEntry(userInputStrings);


### PR DESCRIPTION
This should help to leverage V8's JIT

On GitHub actions this benchmark fails often... locally it runs quite fast