### PR TITLE
Run build and release on v24 (v22 also ships buggy npm version)

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
         with:
-          node-version: "22.x"
+          node-version: "24.x"
           registry-url: "https://registry.npmjs.org"
           scope: "@aikidosec"
       - name: Set up Rust


### PR DESCRIPTION
See https://github.com/npm/cli/issues/8669