### PR TITLE
Set Retry-After header in middleware

### DIFF
--- a/docs/generic-middleware.md
+++ b/docs/generic-middleware.md
@@ -32,9 +32,8 @@ function onRequest(...) {
           message += ` (Your IP: ${result.ip})`;
         }
 
-        // Block the request and send a http 429 status code
-        // Set the Retry-After header to tell the client how long to wait (in seconds)
-        setHeader("Retry-After", result.retryAfterSeconds.toString());
+        // Return a 429 response with a Retry-After header, e.g.:
+        // res.setHeader("Retry-After", result.retryAfterSeconds.toString());
         return ...;
       }
 

--- a/docs/generic-middleware.md
+++ b/docs/generic-middleware.md
@@ -33,6 +33,8 @@ function onRequest(...) {
         }
 
         // Block the request and send a http 429 status code
+        // Set the Retry-After header to tell the client how long to wait (in seconds)
+        setHeader("Retry-After", result.retryAfterSeconds.toString());
         return ...;
       }
 

--- a/library/middleware/express.ts
+++ b/library/middleware/express.ts
@@ -19,7 +19,11 @@ export function addExpressMiddleware(app: Express | Router) {
           message += ` (Your IP: ${escapeHTML(result.ip)})`;
         }
 
-        res.status(429).type("text").send(message);
+        res
+          .status(429)
+          .type("text")
+          .header("Retry-After", result.retryAfterSeconds.toString())
+          .send(message);
         return;
       }
 

--- a/library/middleware/fastify.ts
+++ b/library/middleware/fastify.ts
@@ -5,6 +5,7 @@ import type { FastifyInstance } from "fastify";
 
 export type FastifyReply = {
   status(code: number): FastifyReply;
+  header(key: string, value: string): FastifyReply;
   send(payload: string): FastifyReply;
 };
 
@@ -41,7 +42,10 @@ export const fastifyHook: FastifyHookHandler = (_, reply, done) => {
         message += ` (Your IP: ${escapeHTML(result.ip)})`;
       }
 
-      return reply.status(429).send(message);
+      return reply
+        .status(429)
+        .header("Retry-After", result.retryAfterSeconds.toString())
+        .send(message);
     }
 
     if (result.type === "blocked") {

--- a/library/middleware/hapi.ts
+++ b/library/middleware/hapi.ts
@@ -18,7 +18,11 @@ export function addHapiMiddleware(app: Server) {
           message += ` (Your IP: ${escapeHTML(result.ip)})`;
         }
 
-        return h.response(message).code(429).takeover();
+        return h
+          .response(message)
+          .code(429)
+          .header("Retry-After", result.retryAfterSeconds.toString())
+          .takeover();
       }
 
       if (result.type === "blocked") {

--- a/library/middleware/hono.ts
+++ b/library/middleware/hono.ts
@@ -23,11 +23,9 @@ export function addHonoMiddleware<
           message += ` (Your IP: ${escapeHTML(result.ip)})`;
         }
 
-        const headers: Record<string, string> = {};
-        if (result.retryAfterSeconds !== undefined) {
-          headers["Retry-After"] = String(result.retryAfterSeconds);
-        }
-        return c.text(message, 429, headers);
+        return c.text(message, 429, {
+          "Retry-After": result.retryAfterSeconds.toString(),
+        });
       }
 
       if (result.type === "blocked") {

--- a/library/middleware/hono.ts
+++ b/library/middleware/hono.ts
@@ -23,7 +23,11 @@ export function addHonoMiddleware<
           message += ` (Your IP: ${escapeHTML(result.ip)})`;
         }
 
-        return c.text(message, 429);
+        const headers: Record<string, string> = {};
+        if (result.retryAfterSeconds !== undefined) {
+          headers["Retry-After"] = String(result.retryAfterSeconds);
+        }
+        return c.text(message, 429, headers);
       }
 
       if (result.type === "blocked") {

--- a/library/middleware/koa.ts
+++ b/library/middleware/koa.ts
@@ -22,6 +22,7 @@ export function addKoaMiddleware(app: Application): void {
         ctx.type = "text/plain";
         ctx.body = message;
         ctx.status = 429;
+        ctx.set("Retry-After", result.retryAfterSeconds.toString());
         return;
       }
 

--- a/library/middleware/restify.ts
+++ b/library/middleware/restify.ts
@@ -19,6 +19,7 @@ export function addRestifyMiddleware(server: any) {
 
         res.status(429);
         res.setHeader("Content-Type", "text/plain");
+        res.setHeader("Retry-After", result.retryAfterSeconds.toString());
         res.send(message);
 
         return next(false);

--- a/library/middleware/shouldBlockRequest.ts
+++ b/library/middleware/shouldBlockRequest.ts
@@ -45,12 +45,16 @@ export function shouldBlockRequest(): Result {
     // Mark the request as rate limited in the context
     updateContext(context, "rateLimitedEndpoint", rateLimitResult.endpoint);
 
+    const { retryAfterMs } = rateLimitResult;
+    const retryAfterSeconds =
+      retryAfterMs !== undefined ? Math.ceil(retryAfterMs / 1000) : undefined;
+
     return {
       block: true,
       type: "ratelimited",
       trigger: rateLimitResult.trigger,
       ip: context.remoteAddress,
-      retryAfterSeconds: Math.ceil(rateLimitResult.retryAfterMs / 1000),
+      retryAfterSeconds,
     };
   }
 

--- a/library/middleware/shouldBlockRequest.ts
+++ b/library/middleware/shouldBlockRequest.ts
@@ -4,13 +4,20 @@ import { getInstance } from "../agent/AgentSingleton";
 import { getContext, updateContext } from "../agent/Context";
 import { shouldRateLimitRequest } from "../ratelimiting/shouldRateLimitRequest";
 
-type Result = {
-  block: boolean;
-  type?: "ratelimited" | "blocked";
-  trigger?: "ip" | "user" | "group";
-  ip?: string;
-  retryAfterSeconds?: number;
-};
+type Result =
+  | { block: false }
+  | {
+      block: true;
+      type: "ratelimited";
+      trigger: "ip" | "user" | "group";
+      ip?: string;
+      retryAfterSeconds: number;
+    }
+  | {
+      block: true;
+      type: "blocked";
+      trigger: "user";
+    };
 
 export function shouldBlockRequest(): Result {
   const context = getContext();
@@ -45,16 +52,12 @@ export function shouldBlockRequest(): Result {
     // Mark the request as rate limited in the context
     updateContext(context, "rateLimitedEndpoint", rateLimitResult.endpoint);
 
-    const { retryAfterMs } = rateLimitResult;
-    const retryAfterSeconds =
-      retryAfterMs !== undefined ? Math.ceil(retryAfterMs / 1000) : undefined;
-
     return {
       block: true,
       type: "ratelimited",
       trigger: rateLimitResult.trigger,
       ip: context.remoteAddress,
-      retryAfterSeconds,
+      retryAfterSeconds: Math.ceil(rateLimitResult.retryAfterMs / 1000),
     };
   }
 

--- a/library/middleware/shouldBlockRequest.ts
+++ b/library/middleware/shouldBlockRequest.ts
@@ -9,6 +9,7 @@ type Result = {
   type?: "ratelimited" | "blocked";
   trigger?: "ip" | "user" | "group";
   ip?: string;
+  retryAfterSeconds?: number;
 };
 
 export function shouldBlockRequest(): Result {
@@ -49,6 +50,7 @@ export function shouldBlockRequest(): Result {
       type: "ratelimited",
       trigger: rateLimitResult.trigger,
       ip: context.remoteAddress,
+      retryAfterSeconds: Math.ceil(rateLimitResult.retryAfterMs / 1000),
     };
   }
 

--- a/library/middleware/shouldBlockRequest.ts
+++ b/library/middleware/shouldBlockRequest.ts
@@ -57,7 +57,7 @@ export function shouldBlockRequest(): Result {
       type: "ratelimited",
       trigger: rateLimitResult.trigger,
       ip: context.remoteAddress,
-      retryAfterSeconds: Math.ceil(rateLimitResult.retryAfterMs / 1000),
+      retryAfterSeconds: rateLimitResult.retryAfterSeconds,
     };
   }
 

--- a/library/ratelimiting/RateLimiter.test.ts
+++ b/library/ratelimiting/RateLimiter.test.ts
@@ -283,7 +283,7 @@ t.test("should handle sliding window with burst requests", async (t) => {
   );
 });
 
-t.test("should return retryAfterMs when rate limited", async (t) => {
+t.test("should return retryAfterSeconds when rate limited", async (t) => {
   const windowSize = 10000;
   const max = 2;
   const limiter = new RateLimiter(max, windowSize);
@@ -299,14 +299,12 @@ t.test("should return retryAfterMs when rate limited", async (t) => {
   const result = limiter.isAllowed(key, windowSize, max);
   t.equal(result.allowed, false);
   if (!result.allowed) {
-    // Oldest timestamp is at t=0, window is 10000ms, current time is 5000ms
-    // retryAfterMs = 0 + 10000 - 5000 = 5000
-    t.equal(result.retryAfterMs, 5000);
+    t.equal(result.retryAfterSeconds, 5);
   }
 });
 
 t.test(
-  "retryAfterMs decreases as time passes towards window expiry",
+  "retryAfterSeconds decreases as time passes towards window expiry",
   async (t) => {
     const windowSize = 10000;
     const max = 1;
@@ -319,7 +317,7 @@ t.test(
     const result = limiter.isAllowed(key, windowSize, max);
     t.equal(result.allowed, false);
     if (!result.allowed) {
-      t.equal(result.retryAfterMs, 6000);
+      t.equal(result.retryAfterSeconds, 6);
     }
 
     clock.tick(3000);
@@ -327,7 +325,7 @@ t.test(
     const result2 = limiter.isAllowed(key, windowSize, max);
     t.equal(result2.allowed, false);
     if (!result2.allowed) {
-      t.equal(result2.retryAfterMs, 3000);
+      t.equal(result2.retryAfterSeconds, 3);
     }
   }
 );

--- a/library/ratelimiting/RateLimiter.test.ts
+++ b/library/ratelimiting/RateLimiter.test.ts
@@ -27,13 +27,15 @@ const maxAmount = 5;
 t.test("should allow up to maxAmount requests within TTL", async (t) => {
   const limiter = new RateLimiter(maxAmount, ttl);
   for (let i = 0; i < maxAmount; i++) {
-    t.ok(
+    t.same(
       limiter.isAllowed(key, ttl, maxAmount),
+      { allowed: true },
       `Request ${i + 1} should be allowed`
     );
   }
-  t.notOk(
-    limiter.isAllowed(key, ttl, maxAmount),
+  t.equal(
+    limiter.isAllowed(key, ttl, maxAmount).allowed,
+    false,
     `Request ${maxAmount + 1} should not be allowed`
   );
 });
@@ -41,20 +43,23 @@ t.test("should allow up to maxAmount requests within TTL", async (t) => {
 t.test("should reset after TTL has expired", async (t) => {
   const limiter = new RateLimiter(maxAmount, ttl);
   for (let i = 0; i < maxAmount; i++) {
-    t.ok(
+    t.same(
       limiter.isAllowed(key, ttl, maxAmount),
+      { allowed: true },
       `Request ${i + 1} should be allowed`
     );
   }
-  t.notOk(
-    limiter.isAllowed(key, ttl, maxAmount),
+  t.equal(
+    limiter.isAllowed(key, ttl, maxAmount).allowed,
+    false,
     `Request ${maxAmount + 1} should not be allowed`
   );
 
   clock.tick(ttl + 1);
 
-  t.ok(
+  t.same(
     limiter.isAllowed(key, ttl, maxAmount),
+    { allowed: true },
     `Request after TTL should be allowed`
   );
 });
@@ -64,25 +69,29 @@ t.test("should allow requests for different keys independently", async (t) => {
   const key2 = "user2";
 
   for (let i = 0; i < maxAmount; i++) {
-    t.ok(
+    t.same(
       limiter.isAllowed(key, ttl, maxAmount),
+      { allowed: true },
       `Request ${i + 1} for key1 should be allowed`
     );
   }
-  t.notOk(
-    limiter.isAllowed(key, ttl, maxAmount),
+  t.equal(
+    limiter.isAllowed(key, ttl, maxAmount).allowed,
+    false,
     `Request ${maxAmount + 1} for key1 should not be allowed`
   );
 
   for (let i = 0; i < maxAmount; i++) {
-    t.ok(
+    t.same(
       limiter.isAllowed(key2, ttl, maxAmount),
+      { allowed: true },
       `Request ${i + 1} for key2 should be allowed`
     );
   }
 
-  t.notOk(
-    limiter.isAllowed(key2, ttl, maxAmount),
+  t.equal(
+    limiter.isAllowed(key2, ttl, maxAmount).allowed,
+    false,
     `Request ${maxAmount + 1} for key2 should not be allowed`
   );
 });
@@ -95,8 +104,9 @@ t.test("should handle TTL expiration", async (t) => {
 
   clock.tick(ttl + 1);
 
-  t.ok(
+  t.same(
     limiter.isAllowed(key, ttl, maxAmount),
+    { allowed: true },
     `Request after TTL should be allowed`
   );
 });
@@ -104,13 +114,15 @@ t.test("should handle TTL expiration", async (t) => {
 t.test("should allow requests exactly at limit", async (t) => {
   const limiter = new RateLimiter(maxAmount, ttl);
   for (let i = 0; i < maxAmount; i++) {
-    t.ok(
+    t.same(
       limiter.isAllowed(key, ttl, maxAmount),
+      { allowed: true },
       `Request ${i + 1} should be allowed`
     );
   }
-  t.notOk(
-    limiter.isAllowed(key, ttl, maxAmount),
+  t.equal(
+    limiter.isAllowed(key, ttl, maxAmount).allowed,
+    false,
     `Request ${maxAmount + 1} should not be allowed`
   );
 });
@@ -118,16 +130,18 @@ t.test("should allow requests exactly at limit", async (t) => {
 t.test("should handle multiple rapid requests", async (t) => {
   const limiter = new RateLimiter(maxAmount, ttl);
   for (let i = 0; i < maxAmount; i++) {
-    t.ok(
+    t.same(
       limiter.isAllowed(key, ttl, maxAmount),
+      { allowed: true },
       `Request ${i + 1} should be allowed`
     );
   }
 
   clock.tick(100);
 
-  t.notOk(
-    limiter.isAllowed(key, ttl, maxAmount),
+  t.equal(
+    limiter.isAllowed(key, ttl, maxAmount).allowed,
+    false,
     `Request ${maxAmount + 1} should not be allowed`
   );
 });
@@ -136,13 +150,15 @@ t.test("should handle different window sizes", async (t) => {
   const limiter = new RateLimiter(maxAmount, ttl);
   const differentWindowSize = 1000; // 1 second window
   for (let i = 0; i < maxAmount; i++) {
-    t.ok(
+    t.same(
       limiter.isAllowed(key, differentWindowSize, maxAmount),
+      { allowed: true },
       `Request ${i + 1} should be allowed`
     );
   }
-  t.notOk(
-    limiter.isAllowed(key, differentWindowSize, maxAmount),
+  t.equal(
+    limiter.isAllowed(key, differentWindowSize, maxAmount).allowed,
+    false,
     `Request ${maxAmount + 1} should not be allowed`
   );
 });
@@ -150,8 +166,9 @@ t.test("should handle different window sizes", async (t) => {
 t.test("should handle sliding window with intermittent requests", async (t) => {
   const limiter = new RateLimiter(maxAmount, ttl);
   for (let i = 0; i < maxAmount; i++) {
-    t.ok(
+    t.same(
       limiter.isAllowed(key, ttl, maxAmount),
+      { allowed: true },
       `Request ${i + 1} should be allowed`
     );
     clock.tick(100);
@@ -159,8 +176,9 @@ t.test("should handle sliding window with intermittent requests", async (t) => {
 
   clock.tick(ttl + 1);
 
-  t.ok(
+  t.same(
     limiter.isAllowed(key, ttl, maxAmount),
+    { allowed: true },
     `Request after sliding window should be allowed`
   );
 });
@@ -168,23 +186,26 @@ t.test("should handle sliding window with intermittent requests", async (t) => {
 t.test("should handle sliding window edge case", async (t) => {
   const limiter = new RateLimiter(maxAmount, ttl);
   for (let i = 0; i < maxAmount; i++) {
-    t.ok(
+    t.same(
       limiter.isAllowed(key, ttl, maxAmount),
+      { allowed: true },
       `Request ${i + 1} should be allowed`
     );
   }
 
   clock.tick(ttl + 1);
 
-  t.ok(
+  t.same(
     limiter.isAllowed(key, ttl, maxAmount),
+    { allowed: true },
     `Request after sliding window should be allowed`
   );
 
   clock.tick(ttl + 1);
 
-  t.ok(
+  t.same(
     limiter.isAllowed(key, ttl, maxAmount),
+    { allowed: true },
     `Request after sliding window should be allowed`
   );
 });
@@ -192,8 +213,9 @@ t.test("should handle sliding window edge case", async (t) => {
 t.test("should handle sliding window with delayed requests", async (t) => {
   const limiter = new RateLimiter(maxAmount, ttl);
   for (let i = 0; i < maxAmount; i++) {
-    t.ok(
+    t.same(
       limiter.isAllowed(key, ttl, maxAmount),
+      { allowed: true },
       `Request ${i + 1} should be allowed`
     );
     clock.tick(100);
@@ -201,8 +223,9 @@ t.test("should handle sliding window with delayed requests", async (t) => {
 
   clock.tick(ttl + 1);
 
-  t.ok(
+  t.same(
     limiter.isAllowed(key, ttl, maxAmount),
+    { allowed: true },
     `Request after sliding window should be allowed`
   );
 });
@@ -210,45 +233,101 @@ t.test("should handle sliding window with delayed requests", async (t) => {
 t.test("should handle sliding window with burst requests", async (t) => {
   const limiter = new RateLimiter(maxAmount, ttl);
   for (let i = 0; i < maxAmount; i++) {
-    t.ok(
+    t.same(
       limiter.isAllowed(key, ttl, maxAmount),
+      { allowed: true },
       `Request ${i + 1} should be allowed`
     );
   }
 
   clock.tick(ttl / 2 + 1);
 
-  t.notOk(
-    limiter.isAllowed(key, ttl, maxAmount),
+  t.equal(
+    limiter.isAllowed(key, ttl, maxAmount).allowed,
+    false,
     `Request ${maxAmount + 1} should not be allowed`
   );
-  t.notOk(
-    limiter.isAllowed(key, ttl, maxAmount),
+  t.equal(
+    limiter.isAllowed(key, ttl, maxAmount).allowed,
+    false,
     `Request ${maxAmount + 2} should not be allowed`
   );
-  t.notOk(
-    limiter.isAllowed(key, ttl, maxAmount),
+  t.equal(
+    limiter.isAllowed(key, ttl, maxAmount).allowed,
+    false,
     `Request ${maxAmount + 3} should not be allowed`
   );
 
   clock.tick(ttl / 2 + 1);
 
   for (let i = 0; i < 2; i++) {
-    t.ok(
+    t.same(
       limiter.isAllowed(key, ttl, maxAmount),
+      { allowed: true },
       `Request ${i + 1} should be allowed`
     );
   }
 
-  t.notOk(
-    limiter.isAllowed(key, ttl, maxAmount),
+  t.equal(
+    limiter.isAllowed(key, ttl, maxAmount).allowed,
+    false,
     `Request ${maxAmount + 1} should not be allowed`
   );
 
   clock.tick(ttl + 1);
 
-  t.ok(
+  t.same(
     limiter.isAllowed(key, ttl, maxAmount),
+    { allowed: true },
     `Request after sliding window should be allowed`
   );
 });
+
+t.test("should return retryAfterMs when rate limited", async (t) => {
+  const windowSize = 10000;
+  const max = 2;
+  const limiter = new RateLimiter(max, windowSize);
+
+  t.same(limiter.isAllowed(key, windowSize, max), { allowed: true });
+
+  clock.tick(3000);
+
+  t.same(limiter.isAllowed(key, windowSize, max), { allowed: true });
+
+  clock.tick(2000);
+
+  const result = limiter.isAllowed(key, windowSize, max);
+  t.equal(result.allowed, false);
+  if (!result.allowed) {
+    // Oldest timestamp is at t=0, window is 10000ms, current time is 5000ms
+    // retryAfterMs = 0 + 10000 - 5000 = 5000
+    t.equal(result.retryAfterMs, 5000);
+  }
+});
+
+t.test(
+  "retryAfterMs decreases as time passes towards window expiry",
+  async (t) => {
+    const windowSize = 10000;
+    const max = 1;
+    const limiter = new RateLimiter(max, windowSize);
+
+    t.same(limiter.isAllowed(key, windowSize, max), { allowed: true });
+
+    clock.tick(4000);
+
+    const result = limiter.isAllowed(key, windowSize, max);
+    t.equal(result.allowed, false);
+    if (!result.allowed) {
+      t.equal(result.retryAfterMs, 6000);
+    }
+
+    clock.tick(3000);
+
+    const result2 = limiter.isAllowed(key, windowSize, max);
+    t.equal(result2.allowed, false);
+    if (!result2.allowed) {
+      t.equal(result2.retryAfterMs, 3000);
+    }
+  }
+);

--- a/library/ratelimiting/RateLimiter.ts
+++ b/library/ratelimiting/RateLimiter.ts
@@ -13,6 +13,22 @@ export class RateLimiter {
     this.rateLimitedItems = new LRUMap(maxItems, timeToLiveInMS);
   }
 
+  getRetryAfterMs(key: string, windowSizeInMS: number): number | undefined {
+    const currentTime = performance.now();
+    const requestTimestamps = this.rateLimitedItems.get(key) ?? [];
+    const filteredTimestamps = requestTimestamps.filter(
+      (timestamp) => currentTime - timestamp <= windowSizeInMS
+    );
+
+    if (filteredTimestamps.length === 0) {
+      return undefined;
+    }
+
+    // filteredTimestamps[0] is the oldest request in the window; once it expires, a slot opens up
+    const msUntilReset = filteredTimestamps[0] + windowSizeInMS - currentTime;
+    return Math.max(0, msUntilReset);
+  }
+
   isAllowed(key: string, windowSizeInMS: number, maxRequests: number): boolean {
     const currentTime = performance.now();
     const requestTimestamps = this.rateLimitedItems.get(key) || [];

--- a/library/ratelimiting/RateLimiter.ts
+++ b/library/ratelimiting/RateLimiter.ts
@@ -1,5 +1,9 @@
 import { LRUMap } from "./LRUMap";
 
+export type RateLimitResult =
+  | { allowed: true }
+  | { allowed: false; retryAfterMs: number };
+
 /**
  * Sliding window rate limiter implementation
  */
@@ -13,23 +17,11 @@ export class RateLimiter {
     this.rateLimitedItems = new LRUMap(maxItems, timeToLiveInMS);
   }
 
-  getRetryAfterMs(key: string, windowSizeInMS: number): number | undefined {
-    const currentTime = performance.now();
-    const requestTimestamps = this.rateLimitedItems.get(key) ?? [];
-    const filteredTimestamps = requestTimestamps.filter(
-      (timestamp) => currentTime - timestamp <= windowSizeInMS
-    );
-
-    if (filteredTimestamps.length === 0) {
-      return undefined;
-    }
-
-    // filteredTimestamps[0] is the oldest request in the window; once it expires, a slot opens up
-    const msUntilReset = filteredTimestamps[0] + windowSizeInMS - currentTime;
-    return Math.max(0, msUntilReset);
-  }
-
-  isAllowed(key: string, windowSizeInMS: number, maxRequests: number): boolean {
+  isAllowed(
+    key: string,
+    windowSizeInMS: number,
+    maxRequests: number
+  ): RateLimitResult {
     const currentTime = performance.now();
     const requestTimestamps = this.rateLimitedItems.get(key) || [];
 
@@ -52,7 +44,15 @@ export class RateLimiter {
     // Update the list of timestamps for the key
     this.rateLimitedItems.set(key, filteredTimestamps);
 
-    // Check if the number of requests is less or equal to the maxRequests
-    return filteredTimestamps.length <= maxRequests;
+    if (filteredTimestamps.length <= maxRequests) {
+      return { allowed: true };
+    }
+
+    const retryAfterMs = Math.max(
+      0,
+      filteredTimestamps[0] + windowSizeInMS - currentTime
+    );
+
+    return { allowed: false, retryAfterMs };
   }
 }

--- a/library/ratelimiting/RateLimiter.ts
+++ b/library/ratelimiting/RateLimiter.ts
@@ -2,7 +2,7 @@ import { LRUMap } from "./LRUMap";
 
 export type RateLimitResult =
   | { allowed: true }
-  | { allowed: false; retryAfterMs: number };
+  | { allowed: false; retryAfterSeconds: number };
 
 /**
  * Sliding window rate limiter implementation
@@ -53,6 +53,6 @@ export class RateLimiter {
       filteredTimestamps[0] + windowSizeInMS - currentTime
     );
 
-    return { allowed: false, retryAfterMs };
+    return { allowed: false, retryAfterSeconds: Math.ceil(retryAfterMs / 1000) };
   }
 }

--- a/library/ratelimiting/RateLimiter.ts
+++ b/library/ratelimiting/RateLimiter.ts
@@ -53,6 +53,9 @@ export class RateLimiter {
       filteredTimestamps[0] + windowSizeInMS - currentTime
     );
 
-    return { allowed: false, retryAfterSeconds: Math.ceil(retryAfterMs / 1000) };
+    return {
+      allowed: false,
+      retryAfterSeconds: Math.ceil(retryAfterMs / 1000),
+    };
   }
 }

--- a/library/ratelimiting/shouldRateLimitRequest.test.ts
+++ b/library/ratelimiting/shouldRateLimitRequest.test.ts
@@ -1,4 +1,5 @@
 import * as t from "tap";
+import * as FakeTimers from "@sinonjs/fake-timers";
 import { ReportingAPIForTesting } from "../agent/api/ReportingAPIForTesting";
 import { Token } from "../agent/api/Token";
 import { EndpointConfig } from "../agent/Config";
@@ -821,3 +822,35 @@ t.test(
     }
   }
 );
+
+t.test("it includes retryAfterSeconds when rate limited", async (t) => {
+  const agent = await createAgent([
+    {
+      method: "POST",
+      route: "/login",
+      forceProtectionOff: false,
+      rateLimiting: {
+        enabled: true,
+        maxRequests: 1,
+        windowSizeInMS: 60000,
+      },
+    },
+  ]);
+
+  const clock = FakeTimers.install();
+
+  t.same(shouldRateLimitRequest(createContext("1.2.3.4"), agent), {
+    block: false,
+  });
+
+  clock.tick(10000);
+
+  const result = shouldRateLimitRequest(createContext("1.2.3.4"), agent);
+  t.equal(result.block, true);
+  if (result.block) {
+    t.equal(result.trigger, "ip");
+    t.equal(result.retryAfterSeconds, 50);
+  }
+
+  clock.uninstall();
+});

--- a/library/ratelimiting/shouldRateLimitRequest.ts
+++ b/library/ratelimiting/shouldRateLimitRequest.ts
@@ -12,16 +12,19 @@ type Result =
       block: true;
       trigger: "ip";
       endpoint: Endpoint;
+      retryAfterMs: number | undefined;
     }
   | {
       block: true;
       trigger: "user";
       endpoint: Endpoint;
+      retryAfterMs: number | undefined;
     }
   | {
       block: true;
       trigger: "group";
       endpoint: Endpoint;
+      retryAfterMs: number | undefined;
     };
 
 export function shouldRateLimitRequest(
@@ -71,16 +74,14 @@ export function shouldRateLimitRequest(
   const { maxRequests, windowSizeInMS } = endpoint.rateLimiting;
 
   if (context.rateLimitGroup) {
+    const key = `${endpoint.method}:${endpoint.route}:group:${context.rateLimitGroup}`;
     const allowed = agent
       .getRateLimiter()
-      .isAllowed(
-        `${endpoint.method}:${endpoint.route}:group:${context.rateLimitGroup}`,
-        windowSizeInMS,
-        maxRequests
-      );
+      .isAllowed(key, windowSizeInMS, maxRequests);
 
     if (!allowed) {
-      return { block: true, trigger: "group", endpoint };
+      const retryAfterMs = agent.getRateLimiter().getRetryAfterMs(key, windowSizeInMS);
+      return { block: true, trigger: "group", endpoint, retryAfterMs };
     }
 
     // Do not check IP or User rate limit if rateLimitGroup is set
@@ -88,16 +89,14 @@ export function shouldRateLimitRequest(
   }
 
   if (context.user) {
+    const key = `${endpoint.method}:${endpoint.route}:user:${context.user.id}`;
     const allowed = agent
       .getRateLimiter()
-      .isAllowed(
-        `${endpoint.method}:${endpoint.route}:user:${context.user.id}`,
-        windowSizeInMS,
-        maxRequests
-      );
+      .isAllowed(key, windowSizeInMS, maxRequests);
 
     if (!allowed) {
-      return { block: true, trigger: "user", endpoint };
+      const retryAfterMs = agent.getRateLimiter().getRetryAfterMs(key, windowSizeInMS);
+      return { block: true, trigger: "user", endpoint, retryAfterMs };
     }
 
     // Do not check IP rate limit if user is set
@@ -105,16 +104,14 @@ export function shouldRateLimitRequest(
   }
 
   if (context.remoteAddress) {
+    const key = `${endpoint.method}:${endpoint.route}:ip:${context.remoteAddress}`;
     const allowed = agent
       .getRateLimiter()
-      .isAllowed(
-        `${endpoint.method}:${endpoint.route}:ip:${context.remoteAddress}`,
-        windowSizeInMS,
-        maxRequests
-      );
+      .isAllowed(key, windowSizeInMS, maxRequests);
 
     if (!allowed) {
-      return { block: true, trigger: "ip", endpoint };
+      const retryAfterMs = agent.getRateLimiter().getRetryAfterMs(key, windowSizeInMS);
+      return { block: true, trigger: "ip", endpoint, retryAfterMs };
     }
   }
 

--- a/library/ratelimiting/shouldRateLimitRequest.ts
+++ b/library/ratelimiting/shouldRateLimitRequest.ts
@@ -80,7 +80,9 @@ export function shouldRateLimitRequest(
       .isAllowed(key, windowSizeInMS, maxRequests);
 
     if (!allowed) {
-      const retryAfterMs = agent.getRateLimiter().getRetryAfterMs(key, windowSizeInMS);
+      const retryAfterMs = agent
+        .getRateLimiter()
+        .getRetryAfterMs(key, windowSizeInMS);
       return { block: true, trigger: "group", endpoint, retryAfterMs };
     }
 
@@ -95,7 +97,9 @@ export function shouldRateLimitRequest(
       .isAllowed(key, windowSizeInMS, maxRequests);
 
     if (!allowed) {
-      const retryAfterMs = agent.getRateLimiter().getRetryAfterMs(key, windowSizeInMS);
+      const retryAfterMs = agent
+        .getRateLimiter()
+        .getRetryAfterMs(key, windowSizeInMS);
       return { block: true, trigger: "user", endpoint, retryAfterMs };
     }
 
@@ -110,7 +114,9 @@ export function shouldRateLimitRequest(
       .isAllowed(key, windowSizeInMS, maxRequests);
 
     if (!allowed) {
-      const retryAfterMs = agent.getRateLimiter().getRetryAfterMs(key, windowSizeInMS);
+      const retryAfterMs = agent
+        .getRateLimiter()
+        .getRetryAfterMs(key, windowSizeInMS);
       return { block: true, trigger: "ip", endpoint, retryAfterMs };
     }
   }

--- a/library/ratelimiting/shouldRateLimitRequest.ts
+++ b/library/ratelimiting/shouldRateLimitRequest.ts
@@ -12,19 +12,19 @@ type Result =
       block: true;
       trigger: "ip";
       endpoint: Endpoint;
-      retryAfterMs: number;
+      retryAfterSeconds: number;
     }
   | {
       block: true;
       trigger: "user";
       endpoint: Endpoint;
-      retryAfterMs: number;
+      retryAfterSeconds: number;
     }
   | {
       block: true;
       trigger: "group";
       endpoint: Endpoint;
-      retryAfterMs: number;
+      retryAfterSeconds: number;
     };
 
 export function shouldRateLimitRequest(
@@ -87,7 +87,7 @@ export function shouldRateLimitRequest(
         block: true,
         trigger: "group",
         endpoint,
-        retryAfterMs: result.retryAfterMs,
+        retryAfterSeconds: result.retryAfterSeconds,
       };
     }
 
@@ -109,7 +109,7 @@ export function shouldRateLimitRequest(
         block: true,
         trigger: "user",
         endpoint,
-        retryAfterMs: result.retryAfterMs,
+        retryAfterSeconds: result.retryAfterSeconds,
       };
     }
 
@@ -131,7 +131,7 @@ export function shouldRateLimitRequest(
         block: true,
         trigger: "ip",
         endpoint,
-        retryAfterMs: result.retryAfterMs,
+        retryAfterSeconds: result.retryAfterSeconds,
       };
     }
   }

--- a/library/ratelimiting/shouldRateLimitRequest.ts
+++ b/library/ratelimiting/shouldRateLimitRequest.ts
@@ -12,19 +12,19 @@ type Result =
       block: true;
       trigger: "ip";
       endpoint: Endpoint;
-      retryAfterMs: number | undefined;
+      retryAfterMs: number;
     }
   | {
       block: true;
       trigger: "user";
       endpoint: Endpoint;
-      retryAfterMs: number | undefined;
+      retryAfterMs: number;
     }
   | {
       block: true;
       trigger: "group";
       endpoint: Endpoint;
-      retryAfterMs: number | undefined;
+      retryAfterMs: number;
     };
 
 export function shouldRateLimitRequest(
@@ -74,16 +74,21 @@ export function shouldRateLimitRequest(
   const { maxRequests, windowSizeInMS } = endpoint.rateLimiting;
 
   if (context.rateLimitGroup) {
-    const key = `${endpoint.method}:${endpoint.route}:group:${context.rateLimitGroup}`;
-    const allowed = agent
+    const result = agent
       .getRateLimiter()
-      .isAllowed(key, windowSizeInMS, maxRequests);
+      .isAllowed(
+        `${endpoint.method}:${endpoint.route}:group:${context.rateLimitGroup}`,
+        windowSizeInMS,
+        maxRequests
+      );
 
-    if (!allowed) {
-      const retryAfterMs = agent
-        .getRateLimiter()
-        .getRetryAfterMs(key, windowSizeInMS);
-      return { block: true, trigger: "group", endpoint, retryAfterMs };
+    if (!result.allowed) {
+      return {
+        block: true,
+        trigger: "group",
+        endpoint,
+        retryAfterMs: result.retryAfterMs,
+      };
     }
 
     // Do not check IP or User rate limit if rateLimitGroup is set
@@ -91,16 +96,21 @@ export function shouldRateLimitRequest(
   }
 
   if (context.user) {
-    const key = `${endpoint.method}:${endpoint.route}:user:${context.user.id}`;
-    const allowed = agent
+    const result = agent
       .getRateLimiter()
-      .isAllowed(key, windowSizeInMS, maxRequests);
+      .isAllowed(
+        `${endpoint.method}:${endpoint.route}:user:${context.user.id}`,
+        windowSizeInMS,
+        maxRequests
+      );
 
-    if (!allowed) {
-      const retryAfterMs = agent
-        .getRateLimiter()
-        .getRetryAfterMs(key, windowSizeInMS);
-      return { block: true, trigger: "user", endpoint, retryAfterMs };
+    if (!result.allowed) {
+      return {
+        block: true,
+        trigger: "user",
+        endpoint,
+        retryAfterMs: result.retryAfterMs,
+      };
     }
 
     // Do not check IP rate limit if user is set
@@ -108,16 +118,21 @@ export function shouldRateLimitRequest(
   }
 
   if (context.remoteAddress) {
-    const key = `${endpoint.method}:${endpoint.route}:ip:${context.remoteAddress}`;
-    const allowed = agent
+    const result = agent
       .getRateLimiter()
-      .isAllowed(key, windowSizeInMS, maxRequests);
+      .isAllowed(
+        `${endpoint.method}:${endpoint.route}:ip:${context.remoteAddress}`,
+        windowSizeInMS,
+        maxRequests
+      );
 
-    if (!allowed) {
-      const retryAfterMs = agent
-        .getRateLimiter()
-        .getRetryAfterMs(key, windowSizeInMS);
-      return { block: true, trigger: "ip", endpoint, retryAfterMs };
+    if (!result.allowed) {
+      return {
+        block: true,
+        trigger: "ip",
+        endpoint,
+        retryAfterMs: result.retryAfterMs,
+      };
     }
   }
 

--- a/library/sources/Express.tests.ts
+++ b/library/sources/Express.tests.ts
@@ -556,6 +556,7 @@ export async function createExpressTests(expressPackageName: string) {
       .set("x-forwarded-for", "1.2.3.4");
     t.same(res2.statusCode, 429);
     t.same(res2.text, "You are rate limited by Zen. (Your IP: 1.2.3.4)");
+    t.ok(parseInt(res2.headers["retry-after"]) > 0);
 
     await sleep(2000);
 

--- a/library/sources/Fastify.test.ts
+++ b/library/sources/Fastify.test.ts
@@ -408,6 +408,7 @@ t.test("it rate limits requests by ip address", opts, async (t) => {
   });
 
   t.same(response4.statusCode, 429);
+  t.ok(parseInt(response4.headers["retry-after"] as string) > 0);
 });
 
 t.test(

--- a/library/sources/GraphQL.ts
+++ b/library/sources/GraphQL.ts
@@ -148,6 +148,7 @@ export class GraphQL implements Wrapper {
             extensions: {
               code: "RATE_LIMITED_BY_ZEN",
               ipAddress: context.remoteAddress,
+              retryAfterSeconds: result.retryAfterSeconds,
             },
           }),
         ],

--- a/library/sources/Hapi.test.ts
+++ b/library/sources/Hapi.test.ts
@@ -222,6 +222,7 @@ t.test("it rate limits based on IP address", async (t) => {
     .set("X-Forwarded-For", "1.2.3.4");
   t.match(response3.status, 429);
   t.match(response3.text, "You are rate limited by Zen. (Your IP: 1.2.3.4)");
+  t.ok(parseInt(response3.headers["retry-after"]) > 0);
 });
 
 t.test("it blocks based on user ID", async (t) => {

--- a/library/sources/Hono.test.ts
+++ b/library/sources/Hono.test.ts
@@ -333,6 +333,7 @@ t.test("it rate limits based on IP address", opts, async (t) => {
     await response3.text(),
     "You are rate limited by Zen. (Your IP: 1.2.3.4)"
   );
+  t.ok(parseInt(response3.headers.get("retry-after")!) > 0);
 
   const response4 = await app.request("/%72ate-limited", {
     method: "GET",

--- a/library/sources/Koa.tests.ts
+++ b/library/sources/Koa.tests.ts
@@ -194,6 +194,7 @@ export async function createKoaTests(koaPackageName: string) {
 
     t.equal(response.status, 429);
     t.match(response.text, "You are rate limited by Zen.");
+    t.ok(parseInt(response.headers["retry-after"]) > 0);
   });
 
   t.test("test legacy generator function middleware", async (t) => {

--- a/library/sources/Restify.tests.ts
+++ b/library/sources/Restify.tests.ts
@@ -204,6 +204,7 @@ export async function createRestifyTests(restifyPackageName: string) {
       .set("x-forwarded-for", "1.2.3.4");
     t.same(res2.statusCode, 429);
     t.same(res2.text, "You are rate limited by Zen. (Your IP: 1.2.3.4)");
+    t.ok(parseInt(res2.headers["retry-after"]) > 0);
 
     await sleep(2000);
 

--- a/library/sources/graphql/shouldRateLimitOperation.ts
+++ b/library/sources/graphql/shouldRateLimitOperation.ts
@@ -17,6 +17,7 @@ type Result =
       remoteAddress: string;
       operationType: "query" | "mutation";
       endpoint: Endpoint;
+      retryAfterSeconds: number;
     }
   | {
       block: true;
@@ -25,6 +26,7 @@ type Result =
       userId: string;
       operationType: "query" | "mutation";
       endpoint: Endpoint;
+      retryAfterSeconds: number;
     }
   | {
       block: true;
@@ -33,6 +35,7 @@ type Result =
       groupId: string;
       operationType: "query" | "mutation";
       endpoint: Endpoint;
+      retryAfterSeconds: number;
     };
 
 export function shouldRateLimitOperation(
@@ -107,7 +110,7 @@ function shouldRateLimitField(
   }
 
   if (context.remoteAddress && !isFromLocalhostInProduction && !isBypassedIP) {
-    const allowed = agent
+    const result = agent
       .getRateLimiter()
       .isAllowed(
         `${context.method}:${context.route}:ip:${context.remoteAddress}:${operationType}:${field.name.value}`,
@@ -115,7 +118,7 @@ function shouldRateLimitField(
         rateLimitedField.rateLimiting.maxRequests
       );
 
-    if (!allowed) {
+    if (!result.allowed) {
       return {
         block: true,
         field: field,
@@ -123,12 +126,13 @@ function shouldRateLimitField(
         remoteAddress: context.remoteAddress,
         operationType: operationType,
         endpoint: match,
+        retryAfterSeconds: Math.ceil(result.retryAfterMs / 1000),
       };
     }
   }
 
   if (context.rateLimitGroup) {
-    const allowed = agent
+    const result = agent
       .getRateLimiter()
       .isAllowed(
         `${context.method}:${context.route}:group:${context.rateLimitGroup}:${operationType}:${field.name.value}`,
@@ -136,7 +140,7 @@ function shouldRateLimitField(
         rateLimitedField.rateLimiting.maxRequests
       );
 
-    if (!allowed) {
+    if (!result.allowed) {
       return {
         block: true,
         field: field,
@@ -144,12 +148,13 @@ function shouldRateLimitField(
         groupId: context.rateLimitGroup,
         operationType: operationType,
         endpoint: match,
+        retryAfterSeconds: Math.ceil(result.retryAfterMs / 1000),
       };
     }
   }
 
   if (context.user) {
-    const allowed = agent
+    const result = agent
       .getRateLimiter()
       .isAllowed(
         `${context.method}:${context.route}:user:${context.user.id}:${operationType}:${field.name.value}`,
@@ -157,7 +162,7 @@ function shouldRateLimitField(
         rateLimitedField.rateLimiting.maxRequests
       );
 
-    if (!allowed) {
+    if (!result.allowed) {
       return {
         block: true,
         field: field,
@@ -165,6 +170,7 @@ function shouldRateLimitField(
         userId: context.user.id,
         operationType: operationType,
         endpoint: match,
+        retryAfterSeconds: Math.ceil(result.retryAfterMs / 1000),
       };
     }
   }

--- a/library/sources/graphql/shouldRateLimitOperation.ts
+++ b/library/sources/graphql/shouldRateLimitOperation.ts
@@ -126,7 +126,7 @@ function shouldRateLimitField(
         remoteAddress: context.remoteAddress,
         operationType: operationType,
         endpoint: match,
-        retryAfterSeconds: Math.ceil(result.retryAfterMs / 1000),
+        retryAfterSeconds: result.retryAfterSeconds,
       };
     }
   }
@@ -148,7 +148,7 @@ function shouldRateLimitField(
         groupId: context.rateLimitGroup,
         operationType: operationType,
         endpoint: match,
-        retryAfterSeconds: Math.ceil(result.retryAfterMs / 1000),
+        retryAfterSeconds: result.retryAfterSeconds,
       };
     }
   }
@@ -170,7 +170,7 @@ function shouldRateLimitField(
         userId: context.user.id,
         operationType: operationType,
         endpoint: match,
-        retryAfterSeconds: Math.ceil(result.retryAfterMs / 1000),
+        retryAfterSeconds: result.retryAfterSeconds,
       };
     }
   }


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Changed RateLimiter to return retry-after seconds instead of boolean.
* Propagated retryAfterSeconds through rate-limiting checks into shouldBlockRequest.
* Added Retry-After header to all middleware frameworks for rate limits.
* Updated tests to assert presence and value of Retry-After headers.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/107401169?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->