### PR TITLE
Log response body on config polling errors

### DIFF
--- a/library/agent/realtime/getConfigLastUpdatedAt.ts
+++ b/library/agent/realtime/getConfigLastUpdatedAt.ts
@@ -1,3 +1,4 @@
+import { escapeLog } from "../../helpers/escapeLog";
 import { fetch } from "../../helpers/fetch";
 import { Token } from "../api/Token";
 import { getRealtimeURL } from "./getRealtimeURL";
@@ -15,11 +16,13 @@ export async function getConfigLastUpdatedAt(token: Token): Promise<number> {
   });
 
   if (statusCode === 401) {
-    throw new Error("Token is invalid");
+    throw new Error(`Token is invalid: ${escapeLog(body)}`);
   }
 
   if (statusCode !== 200) {
-    throw new Error(`Expected status code 200, got ${statusCode}`);
+    throw new Error(
+      `Expected status code 200, got ${statusCode}: ${escapeLog(body)}`
+    );
   }
 
   const response: RealtimeResponse = JSON.parse(body);


### PR DESCRIPTION
When config polling fails, we only logged "Token is invalid" without any detail about what the server actually returned. This made it hard to tell whether the request reached our server at all or got intercepted by a proxy.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Logged HTTP response body when config polling returned error statuses


<sup>[More info](https://app.aikido.dev/featurebranch/scan/107415267?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->