### PR TITLE
Add support for Node.js v26

### DIFF
--- a/.github/workflows/alpine-test.yml
+++ b/.github/workflows/alpine-test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16, 18, 20, 22, 24, 25, 26]
+        node-version: [16, 18, 20, 22, 24, 25]
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/alpine-test.yml
+++ b/.github/workflows/alpine-test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16, 18, 20, 22, 24, 25]
+        node-version: [16, 18, 20, 22, 24, 25, 26]
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -24,6 +24,10 @@ jobs:
             mode: "new"
           - node-version: 25.x
             mode: "new"
+          - node-version: 26.x
+            mode: "old"
+          - node-version: 26.x
+            mode: "new"
 
     steps:
       - name: Checkout repository
@@ -41,7 +45,7 @@ jobs:
 
       - name: Downgrade npm for v24 and v25
         # https://github.com/npm/cli/issues/8669
-        if: ${{ matrix.node-version == '24.x' || matrix.node-version == '25.x' }}
+        if: ${{ matrix.node-version == '24.x' || matrix.node-version == '25.x' || matrix.node-version == '26.x' }}
         run: npm i -g npm@11.6.0
 
       - name: Add local.aikido.io to /etc/hosts

--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -25,8 +25,6 @@ jobs:
           - node-version: 25.x
             mode: "new"
           - node-version: 26.x
-            mode: "old"
-          - node-version: 26.x
             mode: "new"
 
     steps:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -46,6 +46,15 @@ jobs:
           - node-version: 25.x
             instrumentation: "new"
             mode: "esm"
+          - node-version: 26.x
+            instrumentation: "current"
+            mode: "cjs"
+          - node-version: 26.x
+            instrumentation: "new"
+            mode: "cjs"
+          - node-version: 26.x
+            instrumentation: "new"
+            mode: "esm"
 
     steps:
       - name: Checkout repository
@@ -63,7 +72,7 @@ jobs:
 
       - name: Downgrade npm for v24 and v25
         # https://github.com/npm/cli/issues/8669
-        if: ${{ matrix.node-version == '24.x' || matrix.node-version == '25.x' }}
+        if: ${{ matrix.node-version == '24.x' || matrix.node-version == '25.x' || matrix.node-version == '26.x' }}
         run: npm i -g npm@11.6.0
 
       - name: Add local.aikido.io to /etc/hosts

--- a/end2end/tests-new/adonis-sqlite.test.mjs
+++ b/end2end/tests-new/adonis-sqlite.test.mjs
@@ -3,9 +3,15 @@ import { getRandomPort } from "./utils/get-port.mjs";
 import { spawnSync, spawn } from "node:child_process";
 import { resolve, join } from "node:path";
 import { timeout } from "./utils/timeout.mjs";
-import { test, before } from "node:test";
+import { test, before, skip } from "node:test";
 import { equal, fail, match, doesNotMatch } from "node:assert";
 import { mkdirSync } from "node:fs";
+
+const majorNodeVersion = parseInt(process.versions.node.split(".")[0], 10);
+if (majorNodeVersion >= 26) {
+  skip("App not working on Node.js v26");
+  process.exit(0);
+}
 
 const pathToAppDir = resolve(
   import.meta.dirname,

--- a/end2end/tests-new/adonis-sqlite.test.mjs
+++ b/end2end/tests-new/adonis-sqlite.test.mjs
@@ -27,12 +27,12 @@ const envVars = {
 };
 
 before(() => {
-  const { stderr } = spawnSync(`node`, ["ace", "build"], {
+  const { status, stderr } = spawnSync(`node`, ["ace", "build"], {
     cwd: pathToAppDir,
     env: envVars,
   });
 
-  if (stderr && stderr.toString().length > 0) {
+  if (status !== 0) {
     throw new Error(`Failed to build: ${stderr.toString()}`);
   }
 

--- a/end2end/tests-new/adonis-sqlite.test.mjs
+++ b/end2end/tests-new/adonis-sqlite.test.mjs
@@ -7,12 +7,6 @@ import { test, before, skip } from "node:test";
 import { equal, fail, match, doesNotMatch } from "node:assert";
 import { mkdirSync } from "node:fs";
 
-const majorNodeVersion = parseInt(process.versions.node.split(".")[0], 10);
-if (majorNodeVersion >= 26) {
-  skip("App not working on Node.js v26");
-  process.exit(0);
-}
-
 const pathToAppDir = resolve(
   import.meta.dirname,
   "../../sample-apps/adonis-sqlite"

--- a/library/package-lock.json
+++ b/library/package-lock.json
@@ -51,7 +51,7 @@
         "ai-v6": "npm:ai@^6.0.3",
         "aws-sdk": "^2.1595.0",
         "axios": "^1.8.4",
-        "better-sqlite3": "^12.2.0",
+        "better-sqlite3": "^12.10.0",
         "bson-objectid": "^2.0.4",
         "cookie-parser": "^1.4.6",
         "express": "^5.0.0",
@@ -6882,7 +6882,9 @@
       }
     },
     "node_modules/better-sqlite3": {
-      "version": "12.5.0",
+      "version": "12.10.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.10.0.tgz",
+      "integrity": "sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -6891,7 +6893,7 @@
         "prebuild-install": "^7.1.1"
       },
       "engines": {
-        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
       }
     },
     "node_modules/bignumber.js": {

--- a/library/package.json
+++ b/library/package.json
@@ -97,7 +97,7 @@
     "ai-v6": "npm:ai@^6.0.3",
     "aws-sdk": "^2.1595.0",
     "axios": "^1.8.4",
-    "better-sqlite3": "^12.2.0",
+    "better-sqlite3": "^12.10.0",
     "bson-objectid": "^2.0.4",
     "cookie-parser": "^1.4.6",
     "express": "^5.0.0",

--- a/library/sinks/Fetch.test.ts
+++ b/library/sinks/Fetch.test.ts
@@ -146,11 +146,14 @@ t.test(
         .getEvents()
         .filter((e) => e.type === "detected_attack");
       t.same(events.length, 1);
-      t.same(events[0].attack.metadata, {
-        hostname: "localhost",
-        port: "4000",
-        privateIP: "::1",
-      });
+      t.same(events[0].attack.metadata.hostname, "localhost");
+      t.same(events[0].attack.metadata.port, "4000");
+      // localhost resolves to ::1 on older Node.js and 127.0.0.1 on Node.js v26+
+      t.ok(
+        events[0].attack.metadata.privateIP === "::1" ||
+          events[0].attack.metadata.privateIP === "127.0.0.1",
+        "privateIP should be a localhost address"
+      );
 
       const error2 = await t.rejects(() =>
         fetch(new URL("http://localhost:4000/api/internal"))

--- a/library/sinks/Fetch.ts
+++ b/library/sinks/Fetch.ts
@@ -166,7 +166,7 @@ export class Fetch implements Wrapper {
         // @ts-expect-error Type is not defined
         globalThis[sym1] = newAgent;
       }
-    } catch (err) {
+    } catch {
       agent.log(
         `Failed to patch global dispatcher for fetch, we can't provide protection!`
       );

--- a/library/sinks/Fetch.ts
+++ b/library/sinks/Fetch.ts
@@ -116,42 +116,57 @@ export class Fetch implements Wrapper {
 
   // We'll set a global dispatcher that will allow us to inspect the resolved IPs (and thus preventing TOCTOU attacks)
   private patchGlobalDispatcher(agent: Agent) {
-    const undiciGlobalDispatcherSymbol = Symbol.for(
-      "undici.globalDispatcher.1"
-    );
+    const sym1 = Symbol.for("undici.globalDispatcher.1");
+    // Node.js v26+ introduced a second symbol where the real undici Agent lives.
+    // Symbol 1 becomes a Dispatcher1Wrapper (a compatibility shim)
+    const sym2 = Symbol.for("undici.globalDispatcher.2");
 
     // @ts-expect-error Type is not defined
-    const dispatcher = globalThis[undiciGlobalDispatcherSymbol];
+    const dispatcher1 = globalThis[sym1];
+    // @ts-expect-error Type is not defined
+    const dispatcher2 = globalThis[sym2];
 
-    if (!dispatcher) {
+    // The real undici Agent: prefer sym2 (Node.js v26+), fall back to sym1 (older).
+    const realDispatcher = dispatcher2 || dispatcher1;
+
+    if (!realDispatcher) {
       agent.log(
         `global dispatcher not found for fetch, we can't provide protection!`
       );
       return;
     }
 
-    if (dispatcher.constructor.name !== "Agent") {
+    if (realDispatcher.constructor.name !== "Agent") {
       agent.log(
-        `Expected Agent as global dispatcher for fetch but found ${dispatcher.constructor.name}, we can't provide protection!`
+        `Expected Agent as global dispatcher for fetch but found ${realDispatcher.constructor.name}, we can't provide protection!`
       );
       return;
     }
 
     try {
-      // @ts-expect-error Type is not defined
-      globalThis[undiciGlobalDispatcherSymbol] = new dispatcher.constructor({
-        connect: {
-          lookup: inspectDNSLookupCalls(lookup, agent, "fetch", "fetch"),
-        },
-      });
+      const lookupFn = inspectDNSLookupCalls(lookup, agent, "fetch", "fetch");
 
-      // @ts-expect-error Type is not defined
-      globalThis[undiciGlobalDispatcherSymbol].dispatch = wrapDispatch(
+      // Create a new Agent with our custom DNS lookup interceptor.
+      const newAgent = new realDispatcher.constructor({
+        connect: { lookup: lookupFn },
+      });
+      newAgent.dispatch = wrapDispatch(newAgent.dispatch, agent);
+
+      if (dispatcher2) {
+        // Node.js v26+: replace the Agent at sym2 and wrap the Dispatcher1Wrapper at sym1.
         // @ts-expect-error Type is not defined
-        globalThis[undiciGlobalDispatcherSymbol].dispatch,
-        agent
-      );
-    } catch {
+        globalThis[sym2] = newAgent;
+        const newWrapper = new dispatcher1.constructor(newAgent);
+        newWrapper.dispatch = wrapDispatch(newWrapper.dispatch, agent);
+
+        // @ts-expect-error Type is not defined
+        globalThis[sym1] = newWrapper;
+      } else {
+        // Older Node.js: only sym1 exists and it is already an Agent.
+        // @ts-expect-error Type is not defined
+        globalThis[sym1] = newAgent;
+      }
+    } catch (err) {
       agent.log(
         `Failed to patch global dispatcher for fetch, we can't provide protection!`
       );

--- a/library/sinks/Undici.ts
+++ b/library/sinks/Undici.ts
@@ -80,7 +80,7 @@ export class Undici implements Wrapper {
 
   private patchGlobalDispatcher(
     agent: Agent,
-    undiciModule: typeof import("undici-v7")
+    undiciModule: typeof import("undici-v8")
   ) {
     const dispatcher = new undiciModule.Agent({
       connect: {
@@ -101,7 +101,7 @@ export class Undici implements Wrapper {
   }
 
   private patchExports(
-    exports: typeof import("undici-v7"),
+    exports: typeof import("undici-v8"),
     pkgInfo: PartialWrapPackageInfo
   ) {
     const agent = getInstance();

--- a/library/sinks/undici/wrapDispatch.ts
+++ b/library/sinks/undici/wrapDispatch.ts
@@ -1,4 +1,4 @@
-import type { Dispatcher } from "undici-v6";
+import type { Dispatcher } from "undici-v8";
 import { getMetadataForSSRFAttack } from "../../vulnerabilities/ssrf/getMetadataForSSRFAttack";
 import { RequestContextStorage } from "./RequestContextStorage";
 import { Context, getContext } from "../../agent/Context";
@@ -8,7 +8,7 @@ import { Agent } from "../../agent/Agent";
 import { attackKindHumanName } from "../../agent/Attack";
 import { escapeHTML } from "../../helpers/escapeHTML";
 import { isRedirectToPrivateIP } from "../../vulnerabilities/ssrf/isRedirectToPrivateIP";
-import { wrapOnHeaders } from "./wrapOnHeaders";
+import { wrapOnHeaders, wrapOnResponseStart } from "./wrapOnHeaders";
 import { cleanError } from "../../helpers/cleanError";
 import { cleanupStackTrace } from "../../helpers/cleanupStackTrace";
 import { getLibraryRoot } from "../../helpers/getLibraryRoot";
@@ -61,12 +61,23 @@ export function wrapDispatch(orig: Dispatch, agent: Agent): Dispatch {
 
     const port = getPortFromURL(url);
 
-    // Wrap onHeaders to check for redirects
-    handler.onHeaders = wrapOnHeaders(
-      handler.onHeaders,
-      { port, url },
-      context
-    );
+    // Wrap redirect detection — undici v7 (Node.js v26+) uses onResponseStart;
+    // undici v6 / older Node.js uses onHeaders.
+    if (typeof handler.onResponseStart === "function") {
+      handler.onResponseStart = wrapOnResponseStart(
+        handler.onResponseStart,
+        { port, url },
+        context
+      );
+    } else {
+      // @ts-expect-error onHeaders is the undici v6 API not present in undici-v8 types
+      handler.onHeaders = wrapOnHeaders(
+        // @ts-expect-error onHeaders is the undici v6 API not present in undici-v8 types
+        handler.onHeaders,
+        { port, url },
+        context
+      );
+    }
 
     return RequestContextStorage.run({ port, url }, () => {
       return orig.apply(

--- a/library/sinks/undici/wrapOnHeaders.ts
+++ b/library/sinks/undici/wrapOnHeaders.ts
@@ -2,13 +2,16 @@ import { RequestContextStorage } from "./RequestContextStorage";
 import { parseHeaders } from "./parseHeaders";
 import { isRedirectStatusCode } from "../../helpers/isRedirectStatusCode";
 import type { Dispatcher } from "undici-v6";
+import type { Dispatcher as DispatcherV8 } from "undici-v8";
 import { Context } from "../../agent/Context";
 import { onRedirect } from "./onRedirect";
 
 type OnHeaders = Dispatcher.DispatchHandlers["onHeaders"];
+type OnResponseStart = DispatcherV8.DispatchHandler["onResponseStart"];
 
 /**
  * Wrap the onHeaders function and check if the response is a redirect. If yes, determine the destination URL and call onRedirect.
+ * This is the undici v6 / legacy handler API
  */
 export function wrapOnHeaders(
   orig: OnHeaders,
@@ -33,6 +36,39 @@ export function wrapOnHeaders(
         } catch {
           // Ignore, log later if we have log levels
         }
+      }
+    }
+
+    if (orig) {
+      return orig.apply(
+        // @ts-expect-error We don't know the type of this
+        this,
+        // @ts-expect-error Arguments are not typed
+        arguments
+      );
+    }
+  };
+}
+
+/**
+ * Wrap the onResponseStart function (undici v7 / Node.js v26+ handler API) and check if the response is a redirect.
+ * Headers are passed as a plain object with lowercase keys instead of a Buffer array.
+ */
+export function wrapOnResponseStart(
+  orig: OnResponseStart,
+  requestContext: ReturnType<typeof RequestContextStorage.getStore>,
+  context: Context
+): OnResponseStart {
+  return function onResponseStart(_controller, statusCode, headers) {
+    if (isRedirectStatusCode(statusCode)) {
+      try {
+        const location = headers?.location;
+        if (typeof location === "string") {
+          const destinationUrl = new URL(location);
+          onRedirect(destinationUrl, requestContext, context);
+        }
+      } catch {
+        // Ignore, log later if we have log levels
       }
     }
 

--- a/sample-apps/adonis-sqlite/package-lock.json
+++ b/sample-apps/adonis-sqlite/package-lock.json
@@ -14,7 +14,7 @@
         "@adonisjs/cors": "^2.2.1",
         "@adonisjs/lucid": "^21.6.1",
         "@aikidosec/firewall": "file:../../build",
-        "better-sqlite3": "^12.4.1",
+        "better-sqlite3": "^12.10.0",
         "luxon": "^3.7.2",
         "reflect-metadata": "^0.2.2"
       },
@@ -981,7 +981,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/@japa/assert/-/assert-4.1.1.tgz",
       "integrity": "sha512-Hhv8A/gkd1b4Xa2Jti4XJ3FsP/pJ8ZXAWwvgYVKZQNcl79lqIHsMjMrL3e475pbf8lybB++FvXi4ruoz2SsiBA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@poppinss/macroable": "^1.0.5",
@@ -1834,7 +1834,7 @@
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
       "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/deep-eql": "*",
@@ -1852,7 +1852,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/estree": {
@@ -2342,7 +2342,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
       "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -2430,9 +2430,9 @@
       "license": "MIT"
     },
     "node_modules/better-sqlite3": {
-      "version": "12.4.1",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.4.1.tgz",
-      "integrity": "sha512-3yVdyZhklTiNrtg+4WqHpJpFDd+WHTg2oM7UcR80GqL05AOV0xEJzc6qNvFYoEtE+hRp1n9MpN6/+4yhlGkDXQ==",
+      "version": "12.10.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.10.0.tgz",
+      "integrity": "sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -2440,7 +2440,7 @@
         "prebuild-install": "^7.1.1"
       },
       "engines": {
-        "node": "20.x || 22.x || 23.x || 24.x"
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
       }
     },
     "node_modules/bindings": {
@@ -2643,7 +2643,7 @@
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
       "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "assertion-error": "^2.0.1",
@@ -2706,7 +2706,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
       "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 16"
@@ -3174,7 +3174,7 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
       "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5052,7 +5052,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
       "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/lru-cache": {
@@ -5652,7 +5652,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
       "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14.16"

--- a/sample-apps/adonis-sqlite/package.json
+++ b/sample-apps/adonis-sqlite/package.json
@@ -52,7 +52,7 @@
     "@adonisjs/cors": "^2.2.1",
     "@adonisjs/lucid": "^21.6.1",
     "@aikidosec/firewall": "file:../../build",
-    "better-sqlite3": "^12.4.1",
+    "better-sqlite3": "^12.10.0",
     "luxon": "^3.7.2",
     "reflect-metadata": "^0.2.2"
   },

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -28,10 +28,10 @@ const INTERNALS_URL = `https://github.com/AikidoSec/zen-internals/releases/downl
 // ---
 
 // Node Internals configuration
-const NODE_INTERNALS_VERSION = "1.0.1";
+const NODE_INTERNALS_VERSION = "1.0.2";
 const NODE_INTERNALS_URL = `https://github.com/AikidoSec/zen-internals-node/releases/download/${NODE_INTERNALS_VERSION}`;
 // 17 is not included on purpose
-const NODE_VERSIONS = [16, 18, 19, 20, 21, 22, 23, 24, 25];
+const NODE_VERSIONS = [16, 18, 19, 20, 21, 22, 23, 24, 25, 26];
 // ---
 
 const rootDir = join(__dirname, "..");

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -28,7 +28,7 @@ const INTERNALS_URL = `https://github.com/AikidoSec/zen-internals/releases/downl
 // ---
 
 // Node Internals configuration
-const NODE_INTERNALS_VERSION = "1.0.2";
+const NODE_INTERNALS_VERSION = "1.0.4";
 const NODE_INTERNALS_URL = `https://github.com/AikidoSec/zen-internals-node/releases/download/${NODE_INTERNALS_VERSION}`;
 // 17 is not included on purpose
 const NODE_VERSIONS = [16, 18, 19, 20, 21, 22, 23, 24, 25, 26];

--- a/scripts/run-tap.js
+++ b/scripts/run-tap.js
@@ -31,7 +31,7 @@ execSync(`tap run ${args}`, {
     ...process.env,
     AIKIDO_CI: "true",
     // In v24 some sub-dependencies are calling require on a esm module triggering an experimental warning
-    NODE_OPTIONS: major === 24 ? "--disable-warning=ExperimentalWarning" : "",
+    NODE_OPTIONS: major >= 24 ? "--disable-warning=ExperimentalWarning" : "",
     AIKIDO_UNIT_TESTS: "1",
   },
 });

--- a/scripts/run-tap.js
+++ b/scripts/run-tap.js
@@ -31,7 +31,7 @@ execSync(`tap run ${args}`, {
     ...process.env,
     AIKIDO_CI: "true",
     // In v24 some sub-dependencies are calling require on a esm module triggering an experimental warning
-    NODE_OPTIONS: major >= 24 ? "--disable-warning=ExperimentalWarning" : "",
+    NODE_OPTIONS: major === 24 ? "--disable-warning=ExperimentalWarning" : "",
     AIKIDO_UNIT_TESTS: "1",
   },
 });


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 3 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added Node.js v26 to CI matrices and npm downgrade condition
* Introduced undici v8 handling and onResponseStart redirect detection
* Patched global fetch dispatcher to support new undici symbols
* Updated build script to include Node 26 and bumped internals
* Bumped dependencies including better-sqlite3 and undici v8 requirement


<sup>[More info](https://app.aikido.dev/featurebranch/scan/116372351?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->