### PR TITLE
fix: Normalize hostnames and remove trailing dot

### DIFF
--- a/library/agent/Hostnames.test.ts
+++ b/library/agent/Hostnames.test.ts
@@ -80,6 +80,15 @@ t.test("it respects max size", async () => {
   ]);
 });
 
+t.test("it normalizes trailing dots", async () => {
+  const hostnames = new Hostnames(3);
+  hostnames.add("aikido.dev.", 443);
+  t.same(hostnames.asArray(), [{ hostname: "aikido.dev", port: 443, hits: 1 }]);
+
+  hostnames.add("aikido.dev", 443);
+  t.same(hostnames.asArray(), [{ hostname: "aikido.dev", port: 443, hits: 2 }]);
+});
+
 t.test("it tracks hits", async () => {
   const hostnames = new Hostnames(3);
 

--- a/library/agent/Hostnames.ts
+++ b/library/agent/Hostnames.ts
@@ -1,3 +1,5 @@
+import { normalizeHostname } from "../helpers/normalizeHostname";
+
 type Ports = Map<number, number>;
 
 export class Hostnames {
@@ -9,6 +11,8 @@ export class Hostnames {
     if (port <= 0) {
       return;
     }
+
+    hostname = normalizeHostname(hostname);
 
     if (!this.map.has(hostname)) {
       this.map.set(hostname, new Map([[port, 1]]));

--- a/library/agent/ServiceConfig.test.ts
+++ b/library/agent/ServiceConfig.test.ts
@@ -425,3 +425,19 @@ t.test("outbound request blocking", async (t) => {
   t.same(config.shouldBlockOutgoingRequest("aikido.dev"), false);
   t.same(config.shouldBlockOutgoingRequest("unknown.com"), false);
 });
+
+t.test("outbound request blocking normalizes trailing dots", async (t) => {
+  const config = new ServiceConfig([], 0, [], [], [], []);
+
+  config.updateDomains([
+    { hostname: "example.com", mode: "block" },
+    { hostname: "aikido.dev", mode: "allow" },
+  ]);
+
+  t.same(config.shouldBlockOutgoingRequest("example.com."), true);
+  t.same(config.shouldBlockOutgoingRequest("aikido.dev."), false);
+
+  config.setBlockNewOutgoingRequests(true);
+  t.same(config.shouldBlockOutgoingRequest("aikido.dev."), false);
+  t.same(config.shouldBlockOutgoingRequest("unknown.com."), true);
+});

--- a/library/agent/ServiceConfig.ts
+++ b/library/agent/ServiceConfig.ts
@@ -1,6 +1,7 @@
 import { addIPv4MappedAddresses } from "../helpers/addIPv4MappedAddresses";
 import { IPMatcher } from "../helpers/ip-matcher/IPMatcher";
 import { LimitedContext, matchEndpoints } from "../helpers/matchEndpoints";
+import { normalizeHostname } from "../helpers/normalizeHostname";
 import { isPrivateIP } from "../vulnerabilities/ssrf/isPrivateIP";
 import type { Endpoint, EndpointConfig, Domain } from "./Config";
 import type { IPList, UserAgentDetails } from "./api/FetchListsAPI";
@@ -296,7 +297,7 @@ export class ServiceConfig {
   }
 
   shouldBlockOutgoingRequest(hostname: string): boolean {
-    const mode = this.domains.get(hostname);
+    const mode = this.domains.get(normalizeHostname(hostname));
 
     if (this.blockNewOutgoingRequests) {
       // Only allow outgoing requests if the mode is "allow"

--- a/library/helpers/normalizeHostname.test.ts
+++ b/library/helpers/normalizeHostname.test.ts
@@ -1,0 +1,15 @@
+import * as t from "tap";
+import { normalizeHostname } from "./normalizeHostname";
+
+t.test("strips trailing dot", async (t) => {
+  t.same(normalizeHostname("example.com."), "example.com");
+  t.same(normalizeHostname("sub.example.com."), "sub.example.com");
+  t.same(normalizeHostname("localhost."), "localhost");
+});
+
+t.test("leaves normal hostnames unchanged", async (t) => {
+  t.same(normalizeHostname("example.com"), "example.com");
+  t.same(normalizeHostname("localhost"), "localhost");
+  t.same(normalizeHostname("192.168.1.1"), "192.168.1.1");
+  t.same(normalizeHostname(""), "");
+});

--- a/library/helpers/normalizeHostname.ts
+++ b/library/helpers/normalizeHostname.ts
@@ -1,0 +1,3 @@
+export function normalizeHostname(hostname: string): string {
+  return hostname.endsWith(".") ? hostname.slice(0, -1) : hostname;
+}

--- a/library/sinks/Fetch.ts
+++ b/library/sinks/Fetch.ts
@@ -5,6 +5,7 @@ import { Hooks } from "../agent/hooks/Hooks";
 import { InterceptorResult } from "../agent/hooks/InterceptorResult";
 import { Wrapper } from "../agent/Wrapper";
 import { getPortFromURL } from "../helpers/getPortFromURL";
+import { normalizeHostname } from "../helpers/normalizeHostname";
 import { tryParseURL } from "../helpers/tryParseURL";
 import { checkContextForSSRF } from "../vulnerabilities/ssrf/checkContextForSSRF";
 import { inspectDNSLookupCalls } from "../vulnerabilities/ssrf/inspectDNSLookupCalls";
@@ -18,6 +19,8 @@ export class Fetch implements Wrapper {
     hostname: string,
     port: number | undefined
   ): InterceptorResult {
+    hostname = normalizeHostname(hostname);
+
     // Let the agent know that we are connecting to this hostname
     // This is to build a list of all hostnames that the application is connecting to
     if (typeof port === "number" && port > 0) {

--- a/library/sinks/HTTPRequest.ts
+++ b/library/sinks/HTTPRequest.ts
@@ -9,6 +9,7 @@ import { getPortFromURL } from "../helpers/getPortFromURL";
 import { checkContextForSSRF } from "../vulnerabilities/ssrf/checkContextForSSRF";
 import { inspectDNSLookupCalls } from "../vulnerabilities/ssrf/inspectDNSLookupCalls";
 import { isRedirectToPrivateIP } from "../vulnerabilities/ssrf/isRedirectToPrivateIP";
+import { normalizeHostname } from "../helpers/normalizeHostname";
 import { getUrlFromHTTPRequestArgs } from "./http-request/getUrlFromHTTPRequestArgs";
 import { wrapResponseHandler } from "./http-request/wrapResponseHandler";
 import { wrapExport } from "../agent/hooks/wrapExport";
@@ -21,15 +22,17 @@ export class HTTPRequest implements Wrapper {
     port: number | undefined,
     module: "http" | "https"
   ): InterceptorResult {
+    const hostname = normalizeHostname(url.hostname);
+
     // Let the agent know that we are connecting to this hostname
     // This is to build a list of all hostnames that the application is connecting to
     if (typeof port === "number" && port > 0) {
-      agent.onConnectHostname(url.hostname, port);
+      agent.onConnectHostname(hostname, port);
     }
 
-    if (agent.getConfig().shouldBlockOutgoingRequest(url.hostname)) {
+    if (agent.getConfig().shouldBlockOutgoingRequest(hostname)) {
       return {
-        hostname: url.hostname,
+        hostname: hostname,
         operation: `${module}.request`,
       };
     }
@@ -42,7 +45,7 @@ export class HTTPRequest implements Wrapper {
 
     // Check if the hostname is inside the context
     const foundDirectSSRF = checkContextForSSRF({
-      hostname: url.hostname,
+      hostname: hostname,
       operation: `${module}.request`,
       context: context,
       port: port,

--- a/library/sinks/http-request/wrapResponseHandler.ts
+++ b/library/sinks/http-request/wrapResponseHandler.ts
@@ -66,7 +66,7 @@ function onHTTPResponse(
     return;
   }
 
-  // Normalize trailing dots
+  // Normalize hostnames to ensure consistent matching for redirect and SSRF detection
   source.hostname = normalizeHostname(source.hostname);
   destination.hostname = normalizeHostname(destination.hostname);
 

--- a/library/sinks/http-request/wrapResponseHandler.ts
+++ b/library/sinks/http-request/wrapResponseHandler.ts
@@ -2,6 +2,7 @@ import { IncomingMessage } from "http";
 import { Context, getContext, updateContext } from "../../agent/Context";
 import { getMajorNodeVersion } from "../../helpers/getNodeVersion";
 import { getPortFromURL } from "../../helpers/getPortFromURL";
+import { normalizeHostname } from "../../helpers/normalizeHostname";
 import { isRedirectStatusCode } from "../../helpers/isRedirectStatusCode";
 import { tryParseURL } from "../../helpers/tryParseURL";
 import { findHostnameInContext } from "../../vulnerabilities/ssrf/findHostnameInContext";
@@ -64,6 +65,10 @@ function onHTTPResponse(
   if (!source) {
     return;
   }
+
+  // Normalize trailing dots
+  source.hostname = normalizeHostname(source.hostname);
+  destination.hostname = normalizeHostname(destination.hostname);
 
   addRedirectToContext(source, destination, context);
 }

--- a/library/sinks/undici/getHostnameAndPortFromArgs.test.ts
+++ b/library/sinks/undici/getHostnameAndPortFromArgs.test.ts
@@ -104,3 +104,31 @@ t.test("without hostname", async (t) => {
   t.same(get([{}]), undefined);
   t.same(get([{ protocol: "https:", port: 4000 }]), undefined);
 });
+
+t.test("it normalizes trailing dots in url string", async (t) => {
+  t.same(get(["http://example.com.:4000"]), {
+    hostname: "example.com",
+    port: 4000,
+  });
+});
+
+t.test("it normalizes trailing dots in url object", async (t) => {
+  t.same(get([new URL("http://example.com.:4000")]), {
+    hostname: "example.com",
+    port: 4000,
+  });
+});
+
+t.test("it normalizes trailing dots in options object hostname", async (t) => {
+  t.same(get([{ hostname: "example.com.", port: 4000 }]), {
+    hostname: "example.com",
+    port: 4000,
+  });
+});
+
+t.test("it normalizes trailing dots in options object origin", async (t) => {
+  t.same(get([{ origin: "http://example.com.:4000" }]), {
+    hostname: "example.com",
+    port: 4000,
+  });
+});

--- a/library/sinks/undici/getHostnameAndPortFromArgs.ts
+++ b/library/sinks/undici/getHostnameAndPortFromArgs.ts
@@ -1,4 +1,5 @@
 import { getPortFromURL } from "../../helpers/getPortFromURL";
+import { normalizeHostname } from "../../helpers/normalizeHostname";
 import { tryParseURL } from "../../helpers/tryParseURL";
 import { isOptionsObject } from "../http-request/isOptionsObject";
 
@@ -36,7 +37,7 @@ export function getHostnameAndPortFromArgs(
     // If url is not undefined, extract the hostname and port
     if (url && url.hostname.length > 0) {
       return {
-        hostname: url.hostname,
+        hostname: normalizeHostname(url.hostname),
         port: getPortFromURL(url),
       };
     }
@@ -61,7 +62,7 @@ function parseOptionsObject(obj: any): HostnameAndPort | undefined {
     const url = tryParseURL(obj.origin);
     if (url) {
       return {
-        hostname: url.hostname,
+        hostname: normalizeHostname(url.hostname),
         port: getPortFromURL(url),
       };
     }
@@ -89,7 +90,7 @@ function parseOptionsObject(obj: any): HostnameAndPort | undefined {
   }
 
   return {
-    hostname: obj.hostname.toLowerCase(),
+    hostname: normalizeHostname(obj.hostname.toLowerCase()),
     port,
   };
 }

--- a/library/vulnerabilities/ssrf/findHostnameInUserInput.test.ts
+++ b/library/vulnerabilities/ssrf/findHostnameInUserInput.test.ts
@@ -101,3 +101,17 @@ t.test("it works with ports", async () => {
     false
   );
 });
+
+t.test("it normalizes trailing dot in hostname parameter", async (t) => {
+  t.same(findHostnameInUserInput("http://example.com", "example.com."), true);
+  t.same(findHostnameInUserInput("example.com", "example.com."), true);
+});
+
+t.test("it normalizes trailing dot in user input", async (t) => {
+  t.same(findHostnameInUserInput("http://example.com.", "example.com"), true);
+  t.same(findHostnameInUserInput("example.com.", "example.com"), true);
+});
+
+t.test("it normalizes trailing dot on both sides", async (t) => {
+  t.same(findHostnameInUserInput("http://example.com.", "example.com."), true);
+});

--- a/library/vulnerabilities/ssrf/findHostnameInUserInput.ts
+++ b/library/vulnerabilities/ssrf/findHostnameInUserInput.ts
@@ -1,4 +1,5 @@
 import { getPortFromURL } from "../../helpers/getPortFromURL";
+import { normalizeHostname } from "../../helpers/normalizeHostname";
 import { tryParseURL } from "../../helpers/tryParseURL";
 
 export function findHostnameInUserInput(
@@ -10,7 +11,7 @@ export function findHostnameInUserInput(
     return false;
   }
 
-  const hostnameURL = tryParseURL(`http://${hostname}`);
+  const hostnameURL = tryParseURL(`http://${normalizeHostname(hostname)}`);
   if (!hostnameURL) {
     return false;
   }
@@ -18,7 +19,10 @@ export function findHostnameInUserInput(
   const variants = [userInput, `http://${userInput}`, `https://${userInput}`];
   for (const variant of variants) {
     const userInputURL = tryParseURL(variant);
-    if (userInputURL && userInputURL.hostname === hostnameURL.hostname) {
+    if (
+      userInputURL &&
+      normalizeHostname(userInputURL.hostname) === hostnameURL.hostname
+    ) {
       const userPort = getPortFromURL(userInputURL);
 
       if (!port) {

--- a/library/vulnerabilities/ssrf/imds.test.ts
+++ b/library/vulnerabilities/ssrf/imds.test.ts
@@ -1,5 +1,5 @@
 import * as t from "tap";
-import { isIMDSIPAddress, isTrustedHostname } from "./imds";
+import { isIMDSIPAddress } from "./imds";
 
 t.test("it returns true for IMDS IP addresses", async (t) => {
   t.same(

--- a/library/vulnerabilities/ssrf/imds.test.ts
+++ b/library/vulnerabilities/ssrf/imds.test.ts
@@ -1,5 +1,5 @@
 import * as t from "tap";
-import { isIMDSIPAddress } from "./imds";
+import { isIMDSIPAddress, isTrustedHostname } from "./imds";
 
 t.test("it returns true for IMDS IP addresses", async (t) => {
   t.same(

--- a/library/vulnerabilities/ssrf/imds.test.ts
+++ b/library/vulnerabilities/ssrf/imds.test.ts
@@ -1,5 +1,5 @@
 import * as t from "tap";
-import { isIMDSIPAddress } from "./imds";
+import { isIMDSIPAddress, isTrustedHostname } from "./imds";
 
 t.test("it returns true for IMDS IP addresses", async (t) => {
   t.same(
@@ -28,4 +28,10 @@ t.test("it returns true for IMDS IP addresses", async (t) => {
 t.test("it returns false for non-IMDS IP addresses", async (t) => {
   t.same(isIMDSIPAddress("1.2.3.4"), false);
   t.same(isIMDSIPAddress("example.com"), false);
+});
+
+t.test("isTrustedHostname normalizes hostnames before checking", async (t) => {
+  t.same(isTrustedHostname("metadata.google.internal."), true);
+  t.same(isTrustedHostname("METADATA.GOOGLE.INTERNAL"), true);
+  t.same(isTrustedHostname("another.hostname"), false);
 });

--- a/library/vulnerabilities/ssrf/imds.ts
+++ b/library/vulnerabilities/ssrf/imds.ts
@@ -1,5 +1,6 @@
 import { addIPv4MappedAddresses } from "../../helpers/addIPv4MappedAddresses";
 import { IPMatcher } from "../../helpers/ip-matcher/IPMatcher";
+import { normalizeHostname } from "../../helpers/normalizeHostname";
 
 // These IP addresses are used to access the instance metadata service (IMDS)
 // We should block any requests to these IP addresses
@@ -23,5 +24,5 @@ export function isIMDSIPAddress(ip: string): boolean {
 const trustedHosts = ["metadata.google.internal", "metadata.goog"];
 
 export function isTrustedHostname(hostname: string): boolean {
-  return trustedHosts.includes(hostname);
+  return trustedHosts.includes(normalizeHostname(hostname.toLowerCase()));
 }

--- a/library/vulnerabilities/ssrf/inspectDNSLookupCalls.test.ts
+++ b/library/vulnerabilities/ssrf/inspectDNSLookupCalls.test.ts
@@ -342,6 +342,7 @@ const imdsMockLookup = (
   if (
     hostname === "imds.test.com" ||
     hostname === "metadata.google.internal" ||
+    hostname === "metadata.google.internal." ||
     hostname === "metadata.goog"
   ) {
     return callback(null, "169.254.169.254", 4);
@@ -483,6 +484,50 @@ t.test("Does not block IMDS SSRF with Google metadata domain", async (t) => {
     }),
   ]);
 });
+
+t.test(
+  "Does not block IMDS SSRF with Google metadata domain with trailing dot",
+  async (t) => {
+    const agent = createTestAgent({
+      token: new Token("123"),
+    });
+    agent.start([]);
+
+    const wrappedLookup = inspectDNSLookupCalls(
+      imdsMockLookup,
+      agent,
+      "module",
+      "operation"
+    );
+
+    await Promise.all([
+      new Promise<void>((resolve) => {
+        wrappedLookup(
+          "metadata.google.internal.",
+          { family: 4 },
+          (err, address) => {
+            t.same(err, null);
+            t.same(address, "169.254.169.254");
+            resolve();
+          }
+        );
+      }),
+      new Promise<void>((resolve) => {
+        runWithContext(context, () => {
+          wrappedLookup(
+            "metadata.google.internal.",
+            { family: 4 },
+            (err, address) => {
+              t.same(err, null);
+              t.same(address, "169.254.169.254");
+              resolve();
+            }
+          );
+        });
+      }),
+    ]);
+  }
+);
 
 t.test("it ignores when the argument is an IP address", async (t) => {
   const agent = createTestAgent({

--- a/library/vulnerabilities/ssrf/inspectDNSLookupCalls.test.ts
+++ b/library/vulnerabilities/ssrf/inspectDNSLookupCalls.test.ts
@@ -529,6 +529,66 @@ t.test(
   }
 );
 
+t.test(
+  "detects SSRF via redirect chain when urlArg hostname has trailing dot",
+  (t) => {
+    const api = new ReportingAPIForTesting();
+    const agent = createTestAgent({ token: new Token("123"), api });
+    agent.start([]);
+    api.clear();
+
+    const hopMockLookup = (
+      hostname: string,
+      options: any,
+      callback: (
+        err: any,
+        address: string | LookupAddress[],
+        family: number
+      ) => void
+    ) => {
+      if (hostname === "hop.internal" || hostname === "hop.internal.") {
+        return callback(null, "127.0.0.1", 4);
+      }
+      return lookup(hostname, options, callback);
+    };
+
+    const urlArg = new URL("http://hop.internal./");
+    const wrappedLookup = inspectDNSLookupCalls(
+      hopMockLookup as any,
+      agent,
+      "http",
+      "request",
+      urlArg
+    );
+
+    runWithContext(
+      {
+        ...context,
+        body: { image: "http://attacker.com" },
+        outgoingRequestRedirects: [
+          {
+            source: new URL("http://attacker.com/"),
+            destination: new URL("http://hop.internal/"),
+          },
+        ],
+      },
+      () => {
+        wrappedLookup("hop.internal.", {}, (err: any, address: any) => {
+          t.same(err instanceof Error, true);
+          if (err instanceof Error) {
+            t.same(
+              err.message,
+              "Zen has blocked a server-side request forgery: request(...) originating from body.image"
+            );
+          }
+          t.same(address, undefined);
+          t.end();
+        });
+      }
+    );
+  }
+);
+
 t.test("it ignores when the argument is an IP address", async (t) => {
   const agent = createTestAgent({
     token: new Token("123"),

--- a/library/vulnerabilities/ssrf/inspectDNSLookupCalls.ts
+++ b/library/vulnerabilities/ssrf/inspectDNSLookupCalls.ts
@@ -6,6 +6,7 @@ import { getContext } from "../../agent/Context";
 import { cleanupStackTrace } from "../../helpers/cleanupStackTrace";
 import { escapeHTML } from "../../helpers/escapeHTML";
 import { isPlainObject } from "../../helpers/isPlainObject";
+import { normalizeHostname } from "../../helpers/normalizeHostname";
 import { getMetadataForSSRFAttack } from "./getMetadataForSSRFAttack";
 import { isPrivateIP } from "./isPrivateIP";
 import { isIMDSIPAddress, isTrustedHostname } from "./imds";
@@ -34,6 +35,9 @@ export function inspectDNSLookupCalls(
       return lookup(...args);
     }
 
+    // Does not modify the original args
+    const normalizedHostname = normalizeHostname(hostname);
+
     const options = args.find((arg) => isPlainObject(arg)) as
       | Record<string, unknown>
       | undefined;
@@ -44,7 +48,7 @@ export function inspectDNSLookupCalls(
           options,
           wrapDNSLookupCallback(
             callback as Function,
-            hostname,
+            normalizedHostname,
             module,
             agent,
             operation,
@@ -56,7 +60,7 @@ export function inspectDNSLookupCalls(
           hostname,
           wrapDNSLookupCallback(
             callback as Function,
-            hostname,
+            normalizedHostname,
             module,
             agent,
             operation,

--- a/library/vulnerabilities/ssrf/inspectDNSLookupCalls.ts
+++ b/library/vulnerabilities/ssrf/inspectDNSLookupCalls.ts
@@ -35,7 +35,7 @@ export function inspectDNSLookupCalls(
       return lookup(...args);
     }
 
-    // Does not modify the original args
+    // Normalize hostname for security checks while preserving original for lookup compatibility
     const normalizedHostname = normalizeHostname(hostname);
 
     const options = args.find((arg) => isPlainObject(arg)) as

--- a/library/vulnerabilities/ssrf/inspectDNSLookupCalls.ts
+++ b/library/vulnerabilities/ssrf/inspectDNSLookupCalls.ts
@@ -168,6 +168,7 @@ function wrapDNSLookupCallback(
       }
 
       if (url) {
+        url.hostname = normalizeHostname(url.hostname);
         // Get the origin of the redirect chain (the first URL in the chain), if the URL is the result of a redirect
         const redirectOrigin = getRedirectOrigin(
           context.outgoingRequestRedirects,


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added hostname normalization helper and applied it across SSRF checks

**🔧 Refactors**
* Stored normalized hostnames in Hostnames map to prevent duplicates


<sup>[More info](https://app.aikido.dev/featurebranch/scan/113203982?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->