### PR TITLE
Fix NoSQL object comparison being too strict

### DIFF
--- a/library/vulnerabilities/nosql-injection/detectNoSQLInjection.test.ts
+++ b/library/vulnerabilities/nosql-injection/detectNoSQLInjection.test.ts
@@ -925,6 +925,28 @@ t.test(
   }
 );
 
+t.test(
+  "detects injection when app adds a non-$ key to a $ operator's subobject",
+  async (t) => {
+    t.same(
+      detectNoSQLInjection(
+        createContext({
+          body: { field: { $elemMatch: { $gt: 5 } } },
+        }),
+        {
+          items: { $elemMatch: { $gt: 5, verified: true } },
+        }
+      ),
+      {
+        injection: true,
+        source: "body",
+        pathsToPayload: [".field.$elemMatch"],
+        payload: { $gt: 5 },
+      }
+    );
+  }
+);
+
 t.test("does not flag when user sends empty object", async (t) => {
   t.same(
     detectNoSQLInjection(
@@ -952,6 +974,57 @@ t.test("does not flag when user object has only non-$ keys", async (t) => {
     { injection: false }
   );
 });
+
+t.test(
+  "does not flag when user $ key is absent from filter operators",
+  async (t) => {
+    t.same(
+      detectNoSQLInjection(
+        createContext({
+          body: { username: { $ne: null } },
+        }),
+        {
+          title: { $exists: true },
+        }
+      ),
+      { injection: false }
+    );
+  }
+);
+
+t.test(
+  "does not flag when filter only uses a subset of user operators",
+  async (t) => {
+    t.same(
+      detectNoSQLInjection(
+        createContext({
+          body: { username: { $ne: null, $gt: 0 } },
+        }),
+        {
+          title: { $ne: null },
+        }
+      ),
+      { injection: false }
+    );
+  }
+);
+
+t.test(
+  "does not flag when app ignores user operators and uses hardcoded filter",
+  async (t) => {
+    t.same(
+      detectNoSQLInjection(
+        createContext({
+          body: { username: { $ne: null } },
+        }),
+        {
+          username: "hardcoded",
+        }
+      ),
+      { injection: false }
+    );
+  }
+);
 
 t.test("not a valid injection attempt", async (t) => {
   t.same(

--- a/library/vulnerabilities/nosql-injection/detectNoSQLInjection.test.ts
+++ b/library/vulnerabilities/nosql-injection/detectNoSQLInjection.test.ts
@@ -864,6 +864,67 @@ t.test("$where js inject with array in request in nested field", async (t) => {
   );
 });
 
+t.test(
+  "detects injection when app merges user operators with its own $ keys",
+  async (t) => {
+    t.same(
+      detectNoSQLInjection(
+        createContext({
+          body: { username: { $ne: null } },
+        }),
+        {
+          title: { $ne: null, $exists: true },
+        }
+      ),
+      {
+        injection: true,
+        source: "body",
+        pathsToPayload: [".username"],
+        payload: { $ne: null, $exists: true },
+      }
+    );
+  }
+);
+
+t.test(
+  "detects injection when app prepends its own $ key before user operators",
+  async (t) => {
+    t.same(
+      detectNoSQLInjection(
+        createContext({
+          body: { username: { $gt: "" } },
+        }),
+        {
+          title: { $exists: true, $gt: "" },
+        }
+      ),
+      {
+        injection: true,
+        source: "body",
+        pathsToPayload: [".username"],
+        payload: { $exists: true, $gt: "" },
+      }
+    );
+  }
+);
+
+t.test(
+  "does not flag when user operator value differs from filter operator value",
+  async (t) => {
+    t.same(
+      detectNoSQLInjection(
+        createContext({
+          body: { username: { $ne: "different" } },
+        }),
+        {
+          title: { $ne: null, $exists: true },
+        }
+      ),
+      { injection: false }
+    );
+  }
+);
+
 t.test("not a valid injection attempt", async (t) => {
   t.same(
     detectNoSQLInjection(

--- a/library/vulnerabilities/nosql-injection/detectNoSQLInjection.test.ts
+++ b/library/vulnerabilities/nosql-injection/detectNoSQLInjection.test.ts
@@ -925,6 +925,34 @@ t.test(
   }
 );
 
+t.test("does not flag when user sends empty object", async (t) => {
+  t.same(
+    detectNoSQLInjection(
+      createContext({
+        body: { username: {} },
+      }),
+      {
+        title: { $exists: true },
+      }
+    ),
+    { injection: false }
+  );
+});
+
+t.test("does not flag when user object has only non-$ keys", async (t) => {
+  t.same(
+    detectNoSQLInjection(
+      createContext({
+        body: { username: { name: "alice" } },
+      }),
+      {
+        title: { $exists: true },
+      }
+    ),
+    { injection: false }
+  );
+});
+
 t.test("not a valid injection attempt", async (t) => {
   t.same(
     detectNoSQLInjection(

--- a/library/vulnerabilities/nosql-injection/detectNoSQLInjection.ts
+++ b/library/vulnerabilities/nosql-injection/detectNoSQLInjection.ts
@@ -41,7 +41,7 @@ function matchFilterPartInUser(
 
   if (isPlainObject(userInput)) {
     const filteredInput = removeKeysThatDontStartWithDollarSign(userInput);
-    if (isDeepStrictEqual(filteredInput, filterPart)) {
+    if (isUserOperatorsSubsetOf(filteredInput, filterPart)) {
       return { match: true, pathToPayload: buildPathToPayload(pathToPayload) };
     }
 
@@ -100,6 +100,28 @@ function removeKeysThatDontStartWithDollarSign(
 
     return acc;
   }, {});
+}
+
+// Returns true if every operator in userOperators is present in filterOperators
+// with the same value — i.e. the user-supplied operators are a subset of the
+// filter. An empty userOperators object never matches (no operators = no injection).
+function isUserOperatorsSubsetOf(
+  userOperators: Record<string, unknown>,
+  filterOperators: Record<string, unknown>
+): boolean {
+  let hasKeys = false;
+  for (const key in userOperators) {
+    // Any missing key or value mismatch means the user input wasn't used as-is.
+    if (
+      !(key in filterOperators) ||
+      !isDeepStrictEqual(userOperators[key], filterOperators[key])
+    ) {
+      return false;
+    }
+    // Only count the key as seen after it passes the check above.
+    hasKeys = true;
+  }
+  return hasKeys;
 }
 
 function findFilterPartWithOperators(


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 1 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Relaxed NoSQL filter matching to accept operator subsets in user input


<sup>[More info](https://app.aikido.dev/featurebranch/scan/120082838?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->