### PR TITLE
Upgrade npm before publish for staged publishing support

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -61,6 +61,9 @@ jobs:
         run: npm run build
       - name: Linting
         run: npm run lint
+      - name: Upgrade npm for staged publishing
+        # npm stage publish requires npm 11.15.0+
+        run: npm i -g npm@11.15.0
       - name: Publish to NPM
         run: |
           if [ "${{ github.event.release.prerelease }}" = "true" ]; then


### PR DESCRIPTION
npm stage publish needs npm 11.15.0+

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Upgraded npm to 11.15.0 before staged publish in build job


<sup>[More info](https://app.aikido.dev/featurebranch/scan/122203173?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->