### PR TITLE
Change early return in path traversal to be case-insensitive

### DIFF
--- a/library/vulnerabilities/path-traversal/detectPathTraversal.test.ts
+++ b/library/vulnerabilities/path-traversal/detectPathTraversal.test.ts
@@ -225,3 +225,16 @@ t.test(
     t.same(detectPathTraversal("//etc//passwd", "/etc"), false);
   }
 );
+
+t.test(
+  "case-insensitive comparison detects traversal on case-insensitive filesystems",
+  async () => {
+    t.same(detectPathTraversal("/etc/passwd", "/ETC/passwd"), true);
+    t.same(detectPathTraversal("/etc/passwd", "/ETC/PASSWD"), true);
+    t.same(
+      detectPathTraversal("/home/user/file.txt", "/HOME/USER/file.txt"),
+      true
+    );
+    t.same(detectPathTraversal("../test.txt", "../"), true);
+  }
+);

--- a/library/vulnerabilities/path-traversal/detectPathTraversal.ts
+++ b/library/vulnerabilities/path-traversal/detectPathTraversal.ts
@@ -35,7 +35,7 @@ export function detectPathTraversal(
     return false;
   }
 
-  if (!filePath.includes(userInput)) {
+  if (!filePath.toLowerCase().includes(userInput.toLowerCase())) {
     // We ignore cases where the user input is not part of the file path.
     return false;
   }


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Made path containment check case-insensitive by lowercasing inputs


<sup>[More info](https://app.aikido.dev/featurebranch/scan/123362678?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->