### PR TITLE
Trim user input before sending to detectSQLInjection

### DIFF
--- a/library/vulnerabilities/sql-injection/detectSQLInjection.test.ts
+++ b/library/vulnerabilities/sql-injection/detectSQLInjection.test.ts
@@ -329,6 +329,13 @@ t.test("It works with non-UTF-8 characters and emojis", async () => {
   isNotSqlInjection("SELECT * FROM users WHERE id = 'a 🛡️'", "a 🛡️");
 });
 
+t.test("detects injection with trailing spaces in user input", async () => {
+  isSqlInjection(
+    "INSERT INTO pets (name, owner) VALUES ('x', 'dummy'), ('injected', 'hacker'); --', 'owner')",
+    "x', 'dummy'), ('injected', 'hacker'); --    "
+  );
+});
+
 const files = [
   // Taken from https://github.com/payloadbox/sql-injection-payload-list/tree/master
   join(__dirname, "payloads", "Auth_Bypass.txt"),

--- a/library/vulnerabilities/sql-injection/detectSQLInjection.ts
+++ b/library/vulnerabilities/sql-injection/detectSQLInjection.ts
@@ -17,13 +17,14 @@ export function detectSQLInjection(
   userInput: string,
   dialect: SQLDialect
 ): SQLInjectionDetectionResultType {
-  if (shouldReturnEarly(query, userInput)) {
+  const userInputNormalized = userInput.toLowerCase().trim();
+  if (shouldReturnEarly(query, userInputNormalized)) {
     return SQLInjectionDetectionResult.SAFE;
   }
 
   const code = wasm_detect_sql_injection(
     query.toLowerCase(),
-    userInput.toLowerCase(),
+    userInputNormalized,
     dialect.getWASMDialectInt()
   );
 


### PR DESCRIPTION
Trims and normalizes user input before SQL injection detection, matching the fix applied to the Java firewall in AikidoSec/firewall-java#298.

**Problem**: An attacker can pad their payload with trailing whitespace (e.g. `"payload   "`). If the DB driver trims this before execution, the SQL query won't contain the padded input, causing `shouldReturnEarly` to incorrectly return `true` (missed detection).

**Fix**: Apply `.toLowerCase().trim()` to the user input before both the early-return check and the WASM detection call.

See: https://github.com/AikidoSec/firewall-java/pull/298

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Normalized and trimmed user input before detection and early-return check


<sup>[More info](https://app.aikido.dev/featurebranch/scan/124637074?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->