### PR TITLE
Fix broken codecov action

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -115,7 +115,7 @@ jobs:
           command: npm run test:esm
 
       - name: Upload coverage
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: ./library/.tap/report/lcov.info,./.esm-tests/tests/lcov.info
           use_oidc: true


### PR DESCRIPTION
Version 6 is failing because it can't download a key to verify the signature, was fixed in v7.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Replaced Codecov action v6 with v7 to fix signature verification


<sup>[More info](https://app.aikido.dev/featurebranch/scan/130021677?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->