### PR TITLE
Stop re-enabling eval when Node disallows code generation

### DIFF
--- a/end2end/tests-new/eval-on-startup.test.mjs
+++ b/end2end/tests-new/eval-on-startup.test.mjs
@@ -1,0 +1,144 @@
+import { spawn } from "child_process";
+import { resolve } from "path";
+import { test } from "node:test";
+import { fail, match, doesNotMatch } from "node:assert";
+import { timeout } from "./utils/timeout.mjs";
+import { getRandomPort } from "./utils/get-port.mjs";
+
+const pathToAppDir = resolve(
+  import.meta.dirname,
+  "../../sample-apps/eval-on-startup"
+);
+const port = await getRandomPort();
+const port2 = await getRandomPort();
+const port3 = await getRandomPort();
+
+// With the flag, Node blocks the new Function() call at startup. Zen uses the same
+// V8 hook, so this checks Zen does not register its callback and re-enable eval. If
+// it did, the app would boot and this test would fail.
+test("it lets Node block code generation when the flag is passed on the CLI", async () => {
+  const server = spawn(
+    `node`,
+    [
+      "--disallow-code-generation-from-strings",
+      "--require",
+      "@aikidosec/firewall/instrument",
+      "./app.js",
+      port,
+    ],
+    {
+      cwd: pathToAppDir,
+      env: {
+        ...process.env,
+        AIKIDO_DEBUG: "true",
+        AIKIDO_BLOCK: "true",
+      },
+    }
+  );
+
+  try {
+    server.on("error", (err) => {
+      fail(err.message);
+    });
+
+    let stdout = "";
+    server.stdout.on("data", (data) => {
+      stdout += data.toString();
+    });
+
+    let stderr = "";
+    server.stderr.on("data", (data) => {
+      stderr += data.toString();
+    });
+
+    await timeout(2000);
+
+    match(stderr, /Code generation from strings disallowed/);
+    doesNotMatch(stdout, /Listening on port/);
+    doesNotMatch(stderr, /Zen will NOT block code injection/);
+  } catch (err) {
+    fail(err);
+  } finally {
+    server.kill();
+  }
+});
+
+// Same as above, but the flag comes from NODE_OPTIONS instead of the CLI.
+test("it lets Node block code generation when the flag is set via NODE_OPTIONS", async () => {
+  const server = spawn(
+    `node`,
+    ["--require", "@aikidosec/firewall/instrument", "./app.js", port2],
+    {
+      cwd: pathToAppDir,
+      env: {
+        ...process.env,
+        AIKIDO_DEBUG: "true",
+        AIKIDO_BLOCK: "true",
+        NODE_OPTIONS: "--disallow-code-generation-from-strings",
+      },
+    }
+  );
+
+  try {
+    server.on("error", (err) => {
+      fail(err.message);
+    });
+
+    let stdout = "";
+    server.stdout.on("data", (data) => {
+      stdout += data.toString();
+    });
+
+    let stderr = "";
+    server.stderr.on("data", (data) => {
+      stderr += data.toString();
+    });
+
+    await timeout(2000);
+
+    match(stderr, /Code generation from strings disallowed/);
+    doesNotMatch(stdout, /Listening on port/);
+    doesNotMatch(stderr, /Zen will NOT block code injection/);
+  } catch (err) {
+    fail(err);
+  } finally {
+    server.kill();
+  }
+});
+
+// Without the flag the app boots fine: there is no request, so Zen allows the
+// startup new Function() call.
+test("it starts normally without the flag", async () => {
+  const server = spawn(
+    `node`,
+    ["--require", "@aikidosec/firewall/instrument", "./app.js", port3],
+    {
+      cwd: pathToAppDir,
+      env: {
+        ...process.env,
+        AIKIDO_DEBUG: "true",
+        AIKIDO_BLOCK: "true",
+      },
+    }
+  );
+
+  try {
+    server.on("error", (err) => {
+      fail(err.message);
+    });
+
+    let stdout = "";
+    server.stdout.on("data", (data) => {
+      stdout += data.toString();
+    });
+
+    await timeout(2000);
+
+    match(stdout, /Code generation works, 1 \+ 1 = 2/);
+    match(stdout, /Listening on port/);
+  } catch (err) {
+    fail(err);
+  } finally {
+    server.kill();
+  }
+});

--- a/library/helpers/isCodeGenerationFromStringsDisallowed.ts
+++ b/library/helpers/isCodeGenerationFromStringsDisallowed.ts
@@ -1,0 +1,19 @@
+// Returns true if Node was started with --disallow-code-generation-from-strings
+// (or via NODE_OPTIONS). With that flag, V8 blocks every eval and new Function()
+// call by itself.
+//
+// We test this by actually trying to build a function. If V8 blocks code generation,
+// it throws an EvalError. Checking the real behavior is more reliable than reading
+// process flags, since it catches every way the flag can be set.
+//
+// Call this before registering our own code generation callback. Once our callback is
+// set it allows code generation when there is no request, which would hide the flag.
+export function isCodeGenerationFromStringsDisallowed(): boolean {
+  try {
+    // oxlint-disable-next-line no-implied-eval
+    new Function("");
+    return false;
+  } catch (error) {
+    return error instanceof EvalError;
+  }
+}

--- a/library/sinks/FunctionSink.ts
+++ b/library/sinks/FunctionSink.ts
@@ -13,6 +13,7 @@ import { existsSync } from "node:fs";
 import { colorText } from "../helpers/colorText";
 import { warnBox } from "../helpers/warnBox";
 import { isMusl } from "../helpers/isMusl";
+import { isCodeGenerationFromStringsDisallowed } from "../helpers/isCodeGenerationFromStringsDisallowed";
 
 export class FunctionSink implements Wrapper {
   private inspectFunction(args: unknown[]): InterceptorResult {
@@ -104,6 +105,16 @@ export class FunctionSink implements Wrapper {
 
   wrap(_: Hooks) {
     if (envToBool(process.env.AIKIDO_DISABLE_CODE_GENERATION_HOOK)) {
+      return;
+    }
+
+    // If Node was started with --disallow-code-generation-from-strings, V8 already
+    // blocks every eval and new Function() call. We use the same V8 hook, so if we
+    // registered our callback it would override that and let eval run again for code
+    // that doesn't come from a request. So we do nothing and let Node keep blocking
+    // everything. No warning needed: we only block eval when the code comes from user
+    // input, and Node already blocks all of it, including those cases.
+    if (isCodeGenerationFromStringsDisallowed()) {
       return;
     }
 

--- a/sample-apps/eval-on-startup/app.js
+++ b/sample-apps/eval-on-startup/app.js
@@ -1,0 +1,20 @@
+require("@aikidosec/firewall");
+
+const http = require("http");
+
+// This app generates code from a string while starting up. With
+// --disallow-code-generation-from-strings, Node blocks this and the app crashes.
+// Zen uses the same V8 hook, so it must not re-enable code generation here.
+const sum = new Function("return 1 + 1")();
+console.log(`Code generation works, 1 + 1 = ${sum}`);
+
+const port = parseInt(process.argv[2], 10) || 4000;
+
+const server = http.createServer((req, res) => {
+  res.writeHead(200, { "Content-Type": "text/plain" });
+  res.end("OK");
+});
+
+server.listen(port, () => {
+  console.log(`Listening on port ${port}`);
+});

--- a/sample-apps/eval-on-startup/package-lock.json
+++ b/sample-apps/eval-on-startup/package-lock.json
@@ -1,0 +1,25 @@
+{
+  "name": "eval-on-startup",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "eval-on-startup",
+      "dependencies": {
+        "@aikidosec/firewall": "file:../../build"
+      }
+    },
+    "../../build": {
+      "name": "@aikidosec/firewall",
+      "version": "0.0.0",
+      "license": "AGPL-3.0-or-later",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@aikidosec/firewall": {
+      "resolved": "../../build",
+      "link": true
+    }
+  }
+}

--- a/sample-apps/eval-on-startup/package.json
+++ b/sample-apps/eval-on-startup/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "eval-on-startup",
+  "main": "app.js",
+  "private": true,
+  "dependencies": {
+    "@aikidosec/firewall": "file:../../build"
+  }
+}


### PR DESCRIPTION
Zen blocks eval and new Function() using the same V8 hook that Node's `--disallow-code-generation-from-strings` flag uses. When that flag was set, registering our callback overrode Node and let eval run again whenever there was no request, so we silently re-enabled the very thing the user had turned off.

Now we check whether code generation is already disallowed before registering, and if so we leave it to Node. No warning is shown: we only block eval when the code comes from user input, and Node already blocks all of it, including those cases.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🚀 New Features**
* Added helper function that detects Node's disallow-code-generation-from-strings flag

**🐛 Bugfixes**
* Prevented re-enabling eval when Node disallowed code generation flag set


<sup>[More info](https://app.aikido.dev/featurebranch/scan/133758178?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->