### PR TITLE
Fix fetch broken in Node.js ^v24.17.0

### DIFF
--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -39,6 +39,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: "npm"
           cache-dependency-path: "**/package-lock.json"
+          check-latest: true
 
       - name: Setup Aikido safe-chain
         run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -68,6 +68,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: "npm"
           cache-dependency-path: "**/package-lock.json"
+          check-latest: true
 
       - name: Setup Aikido safe-chain
         run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci

--- a/library/package-lock.json
+++ b/library/package-lock.json
@@ -113,6 +113,7 @@
         "undici-v5": "npm:undici@^5.0.0",
         "undici-v6": "npm:undici@^6.0.0",
         "undici-v7": "npm:undici@^7.28.0",
+        "undici-v7-old": "npm:undici@7.10.0",
         "undici-v8": "npm:undici@^8.0.0",
         "xml-js": "^1.6.11",
         "xml2js": "^0.6.2",
@@ -17153,6 +17154,17 @@
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
       "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/undici-v7-old": {
+      "name": "undici",
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.10.0.tgz",
+      "integrity": "sha512-u5otvFBOBZvmdjWLVW+5DAc9Nkq8f24g0O9oY7qw2JVIF1VocIFoyz9JFkuVOS2j41AufeO0xnlweJ2RLT8nGw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/library/package-lock.json
+++ b/library/package-lock.json
@@ -112,7 +112,7 @@
         "undici-v4": "npm:undici@^4.0.0",
         "undici-v5": "npm:undici@^5.0.0",
         "undici-v6": "npm:undici@^6.0.0",
-        "undici-v7": "npm:undici@7.10.0",
+        "undici-v7": "npm:undici@^7.28.0",
         "undici-v8": "npm:undici@^8.0.0",
         "xml-js": "^1.6.11",
         "xml2js": "^0.6.2",
@@ -17139,9 +17139,9 @@
     },
     "node_modules/undici-v6": {
       "name": "undici",
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
-      "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -17150,7 +17150,9 @@
     },
     "node_modules/undici-v7": {
       "name": "undici",
-      "version": "7.10.0",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -17159,9 +17161,9 @@
     },
     "node_modules/undici-v8": {
       "name": "undici",
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.0.0.tgz",
-      "integrity": "sha512-RGabV5g1ggSX5mU4k+B8BLWgb418gDbg0wAVFeiU00iOxtw4ufGsE6GFsuSd2uqOKooWSLf71JGapOFYpE8f+A==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.5.0.tgz",
+      "integrity": "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/library/package.json
+++ b/library/package.json
@@ -156,7 +156,7 @@
     "undici-v4": "npm:undici@^4.0.0",
     "undici-v5": "npm:undici@^5.0.0",
     "undici-v6": "npm:undici@^6.0.0",
-    "undici-v7": "npm:undici@7.10.0",
+    "undici-v7": "npm:undici@^7.28.0",
     "undici-v8": "npm:undici@^8.0.0",
     "xml-js": "^1.6.11",
     "xml2js": "^0.6.2",

--- a/library/package.json
+++ b/library/package.json
@@ -156,6 +156,7 @@
     "undici-v4": "npm:undici@^4.0.0",
     "undici-v5": "npm:undici@^5.0.0",
     "undici-v6": "npm:undici@^6.0.0",
+    "undici-v7-old": "npm:undici@7.10.0",
     "undici-v7": "npm:undici@^7.28.0",
     "undici-v8": "npm:undici@^8.0.0",
     "xml-js": "^1.6.11",

--- a/library/sinks/Fetch.ts
+++ b/library/sinks/Fetch.ts
@@ -117,8 +117,9 @@ export class Fetch implements Wrapper {
   // We'll set a global dispatcher that will allow us to inspect the resolved IPs (and thus preventing TOCTOU attacks)
   private patchGlobalDispatcher(agent: Agent) {
     const sym1 = Symbol.for("undici.globalDispatcher.1");
-    // Node.js v26+ introduced a second symbol where the real undici Agent lives.
-    // Symbol 1 becomes a Dispatcher1Wrapper (a compatibility shim)
+    // sym2 was introduced when undici v8 split the real Agent (sym2) from a legacy
+    // Dispatcher1Wrapper shim (sym1). In undici v7 after PR #5368, both symbols point
+    // to the same Agent with no wrapper.
     const sym2 = Symbol.for("undici.globalDispatcher.2");
 
     // @ts-expect-error Type is not defined
@@ -153,14 +154,23 @@ export class Fetch implements Wrapper {
       newAgent.dispatch = wrapDispatch(newAgent.dispatch, agent);
 
       if (dispatcher2) {
-        // Node.js v26+: replace the Agent at sym2 and wrap the Dispatcher1Wrapper at sym1.
         // @ts-expect-error Type is not defined
         globalThis[sym2] = newAgent;
-        const newWrapper = new dispatcher1.constructor(newAgent);
-        newWrapper.dispatch = wrapDispatch(newWrapper.dispatch, agent);
 
-        // @ts-expect-error Type is not defined
-        globalThis[sym1] = newWrapper;
+        if (dispatcher1.constructor.name === "Dispatcher1Wrapper") {
+          // undici v8 (Node.js v26+): sym1 holds a Dispatcher1Wrapper shim around the Agent.
+          const newWrapper = new dispatcher1.constructor(newAgent);
+          newWrapper.dispatch = wrapDispatch(newWrapper.dispatch, agent);
+          // @ts-expect-error Type is not defined
+          globalThis[sym1] = newWrapper;
+        } else {
+          // undici v7: PR #5368 (shipped in Node.js 24.17.0) changed setGlobalDispatcher to mirror
+          // the Agent directly to sym1 instead of wrapping it in Dispatcher1Wrapper.
+          // Creating a new agent would produce a broken dispatcher.
+
+          // @ts-expect-error Type is not defined
+          globalThis[sym1] = newAgent;
+        }
       } else {
         // Older Node.js: only sym1 exists and it is already an Agent.
         // @ts-expect-error Type is not defined

--- a/library/sinks/Undici.v7.test.ts
+++ b/library/sinks/Undici.v7.test.ts
@@ -1,3 +1,6 @@
 import { createUndiciTests } from "./Undici.tests";
+import { getMajorNodeVersion } from "../helpers/getNodeVersion";
 
-createUndiciTests("undici-v7", 4007);
+const libName = getMajorNodeVersion() >= 20 ? "undici-v7" : "undici-v7-old";
+
+createUndiciTests(libName, 4007);

--- a/library/sinks/Undici2.v7.test.ts
+++ b/library/sinks/Undici2.v7.test.ts
@@ -1,3 +1,6 @@
 import { createUndiciTests } from "./Undici2.tests";
+import { getMajorNodeVersion } from "../helpers/getNodeVersion";
 
-createUndiciTests("undici-v7", 5007);
+const libName = getMajorNodeVersion() >= 20 ? "undici-v7" : "undici-v7-old";
+
+createUndiciTests(libName, 5007);


### PR DESCRIPTION
Caused by https://github.com/nodejs/undici/pull/4962

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Updated undici dependency aliases and bumped v7 for compatibility
* Forced setup-node to check latest and adjusted CI Node matrices

**🐛 Bugfixes**
* Fixed fetch global dispatcher patching for Node.js ^v24.17.0


<sup>[More info](https://app.aikido.dev/featurebranch/scan/136753651?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->