### PR TITLE
Bump Zen internals to v0.1.69

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -23,7 +23,7 @@ async function execAsyncWithPipe(command, options) {
 }
 
 // Zen Internals configuration
-const INTERNALS_VERSION = "v0.1.68";
+const INTERNALS_VERSION = "v0.1.69";
 const INTERNALS_URL = `https://github.com/AikidoSec/zen-internals/releases/download/${INTERNALS_VERSION}`;
 // ---
 


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Bumped Zen internals version reference to v0.1.69 in build script


<sup>[More info](https://app.aikido.dev/featurebranch/scan/136817830?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->