### PR TITLE
Fix Unicode URL parsing after warmup

### DIFF
--- a/library/helpers/tryParseURL.ts
+++ b/library/helpers/tryParseURL.ts
@@ -1,29 +1,7 @@
-type ParseFunction = (url: string) => URL | undefined;
-
-let tryParseURL: ParseFunction;
-
-tryParseURL = parseAndCatchError;
-
-function parseAndCatchError(url: string): URL | undefined {
+export function tryParseURL(url: string): URL | undefined {
   try {
     return new URL(url);
   } catch {
     return undefined;
   }
 }
-
-function canParse(url: string): URL | undefined {
-  if (URL.canParse(url)) {
-    return new URL(url);
-  }
-
-  return undefined;
-}
-
-// URL.canParse(...) is a lot faster than using the constructor and catching the error
-// Added in Node.js: v19.9.0, v18.17.0
-if (typeof URL.canParse === "function") {
-  tryParseURL = canParse;
-}
-
-export { tryParseURL };

--- a/library/helpers/tryParseURL.ts
+++ b/library/helpers/tryParseURL.ts
@@ -1,5 +1,11 @@
 import { getMajorNodeVersion } from "./getNodeVersion";
 
+type ParseFunction = (url: string) => URL | undefined;
+
+let tryParseURL: ParseFunction;
+
+tryParseURL = parseAndCatchError;
+
 function parseAndCatchError(url: string): URL | undefined {
   try {
     return new URL(url);
@@ -16,8 +22,10 @@ function canParse(url: string): URL | undefined {
   return undefined;
 }
 
+// URL.canParse(...) is a lot faster than using the constructor and catching the error
 // URL.canParse(...) can give wrong results on Node.js < 24, so we only use it from 24+.
-export const tryParseURL: (url: string) => URL | undefined =
-  typeof URL.canParse === "function" && getMajorNodeVersion() >= 24
-    ? canParse
-    : parseAndCatchError;
+if (typeof URL.canParse === "function" && getMajorNodeVersion() >= 24) {
+  tryParseURL = canParse;
+}
+
+export { tryParseURL };

--- a/library/helpers/tryParseURL.ts
+++ b/library/helpers/tryParseURL.ts
@@ -1,7 +1,23 @@
-export function tryParseURL(url: string): URL | undefined {
+import { getMajorNodeVersion } from "./getNodeVersion";
+
+function parseAndCatchError(url: string): URL | undefined {
   try {
     return new URL(url);
   } catch {
     return undefined;
   }
 }
+
+function canParse(url: string): URL | undefined {
+  if (URL.canParse(url)) {
+    return new URL(url);
+  }
+
+  return undefined;
+}
+
+// URL.canParse(...) can give wrong results on Node.js < 24, so we only use it from 24+.
+export const tryParseURL: (url: string) => URL | undefined =
+  typeof URL.canParse === "function" && getMajorNodeVersion() >= 24
+    ? canParse
+    : parseAndCatchError;

--- a/library/vulnerabilities/ssrf/findHostnameInUserInput.test.ts
+++ b/library/vulnerabilities/ssrf/findHostnameInUserInput.test.ts
@@ -115,3 +115,26 @@ t.test("it normalizes trailing dot in user input", async (t) => {
 t.test("it normalizes trailing dot on both sides", async (t) => {
   t.same(findHostnameInUserInput("http://example.com.", "example.com."), true);
 });
+
+t.test("it reliably parses a Unicode hostname after warmup", async (t) => {
+  for (let i = 0; i < 3_000; i++) {
+    findHostnameInUserInput(`http://example.com/path/${i}`, "example.com", 80);
+  }
+
+  const userInput = JSON.parse(
+    Buffer.concat([
+      Buffer.from('{"url":"http://ssrf-r', "ascii"),
+      Buffer.from([0xc3, 0xa9]),
+      Buffer.from('directs.testssandbox.com/ssrf-test-4"}', "ascii"),
+    ]).toString("utf8")
+  ).url;
+
+  t.same(
+    findHostnameInUserInput(
+      userInput,
+      "xn--ssrf-rdirects-ghb.testssandbox.com",
+      80
+    ),
+    true
+  );
+});


### PR DESCRIPTION
URL.canParse is buggy on Node 20/22 and returns false for Unicode domains after ~3000 calls with regular domains. Node 24 doesn't have this problem.