### PR TITLE
Support gradual rollout flag for realtime updates

### DIFF
--- a/end2end/server/src/zen/config.ts
+++ b/end2end/server/src/zen/config.ts
@@ -33,7 +33,7 @@ export function generateConfig(app: App): AppConfig {
     blockNewOutgoingRequests: false,
     domains: [],
     excludedUserIdsFromRateLimiting: [],
-    realtimeUpdatesEnabled: true,
+    realtimeUpdatesEnabled: false,
   };
 }
 

--- a/end2end/server/src/zen/config.ts
+++ b/end2end/server/src/zen/config.ts
@@ -16,7 +16,7 @@ type AppConfig = {
   failureRate?: number;
   timeout?: number;
   excludedUserIdsFromRateLimiting?: string[];
-  realtimeUpdatesEnabled: boolean;
+  enabledFeatures: string[];
 };
 
 const configs: AppConfig[] = [];
@@ -33,7 +33,7 @@ export function generateConfig(app: App): AppConfig {
     blockNewOutgoingRequests: false,
     domains: [],
     excludedUserIdsFromRateLimiting: [],
-    realtimeUpdatesEnabled: false,
+    enabledFeatures: [],
   };
 }
 

--- a/end2end/server/src/zen/config.ts
+++ b/end2end/server/src/zen/config.ts
@@ -16,6 +16,7 @@ type AppConfig = {
   failureRate?: number;
   timeout?: number;
   excludedUserIdsFromRateLimiting?: string[];
+  realtimeUpdatesEnabled: boolean;
 };
 
 const configs: AppConfig[] = [];
@@ -32,6 +33,7 @@ export function generateConfig(app: App): AppConfig {
     blockNewOutgoingRequests: false,
     domains: [],
     excludedUserIdsFromRateLimiting: [],
+    realtimeUpdatesEnabled: true,
   };
 }
 

--- a/end2end/tests-new/realtime-config-updates.test.mjs
+++ b/end2end/tests-new/realtime-config-updates.test.mjs
@@ -223,7 +223,7 @@ test("it stops SSE reconnect on 401", async () => {
   }
 });
 
-test("it connects via SSE when only realtimeUpdatesEnabled is set, without the local feature flag", async () => {
+test("it connects via SSE when only enabledFeatures includes runtime_updates, without the local feature flag", async () => {
   const response = await fetch(`${testServerUrl}/api/runtime/apps`, {
     method: "POST",
   });
@@ -238,7 +238,7 @@ test("it connects via SSE when only realtimeUpdatesEnabled is set, without the l
       "Content-Type": "application/json",
       Authorization: token,
     },
-    body: JSON.stringify({ realtimeUpdatesEnabled: true }),
+    body: JSON.stringify({ enabledFeatures: ["runtime_updates"] }),
   });
 
   const server = spawnApp(token, port, { enableSSEFeatureFlag: false });

--- a/end2end/tests-new/realtime-config-updates.test.mjs
+++ b/end2end/tests-new/realtime-config-updates.test.mjs
@@ -12,7 +12,7 @@ const pathToAppDir = resolve(
 
 const testServerUrl = "http://localhost:5874";
 
-function spawnApp(token, port) {
+function spawnApp(token, port, { enableSSEFeatureFlag }) {
   return spawn(
     `node`,
     [
@@ -32,7 +32,7 @@ function spawnApp(token, port) {
         AIKIDO_DEBUG: "true",
         AIKIDO_DEBUG_SSE: "true",
         AIKIDO_BLOCK: "true",
-        AIKIDO_FEATURE_SSE: "true",
+        ...(enableSSEFeatureFlag ? { AIKIDO_FEATURE_SSE: "true" } : {}),
       },
     }
   );
@@ -46,7 +46,7 @@ test("it picks up blocked IP via SSE config update", async () => {
   const token = body.token;
   const port = await getRandomPort();
 
-  const server = spawnApp(token, port);
+  const server = spawnApp(token, port, { enableSSEFeatureFlag: true });
 
   try {
     server.on("error", (err) => {
@@ -109,7 +109,7 @@ test("it reconnects SSE after server disconnects", async () => {
   const token = body.token;
   const port = await getRandomPort();
 
-  const server = spawnApp(token, port);
+  const server = spawnApp(token, port, { enableSSEFeatureFlag: true });
 
   try {
     server.on("error", (err) => {
@@ -181,7 +181,7 @@ test("it stops SSE reconnect on 401", async () => {
   const token = body.token;
   const port = await getRandomPort();
 
-  const server = spawnApp(token, port);
+  const server = spawnApp(token, port, { enableSSEFeatureFlag: true });
 
   try {
     server.on("error", (err) => {
@@ -216,6 +216,80 @@ test("it stops SSE reconnect on 401", async () => {
     const rejectedIndex = stdout.indexOf("SSE connection rejected");
     const afterRejected = stdout.slice(rejectedIndex);
     doesNotMatch(afterRejected, /SSE scheduling reconnect/);
+  } catch (err) {
+    fail(err);
+  } finally {
+    server.kill();
+  }
+});
+
+test("it connects via SSE when only realtimeUpdatesEnabled is set, without the local feature flag", async () => {
+  const response = await fetch(`${testServerUrl}/api/runtime/apps`, {
+    method: "POST",
+  });
+  const body = await response.json();
+  const token = body.token;
+  const port = await getRandomPort();
+
+  // Opt in purely via the backend-driven flag, not AIKIDO_FEATURE_SSE
+  await fetch(`${testServerUrl}/api/runtime/config`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: token,
+    },
+    body: JSON.stringify({ realtimeUpdatesEnabled: true }),
+  });
+
+  const server = spawnApp(token, port, { enableSSEFeatureFlag: false });
+
+  try {
+    server.on("error", (err) => {
+      fail(err);
+    });
+
+    let stdout = "";
+    server.stdout.on("data", (data) => {
+      stdout += data.toString();
+    });
+
+    let stderr = "";
+    server.stderr.on("data", (data) => {
+      stderr += data.toString();
+    });
+
+    // Wait for the server to start and SSE to connect
+    await timeout(3000);
+    match(stdout, /SSE connected successfully/);
+
+    // Verify request from 5.6.7.8 is allowed before blocking
+    const before = await fetch(`http://127.0.0.1:${port}/`, {
+      headers: { "x-forwarded-for": "5.6.7.8" },
+      signal: AbortSignal.timeout(5000),
+    });
+    equal(before.status, 200);
+
+    // Block IP 5.6.7.8 via the test server API
+    await fetch(`${testServerUrl}/api/runtime/firewall/lists`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: token,
+      },
+      body: JSON.stringify({
+        blockedIPAddresses: ["5.6.7.8"],
+      }),
+    });
+
+    // Wait for SSE config-updated event to propagate
+    await timeout(2000);
+
+    // Verify request from 5.6.7.8 is now blocked
+    const after = await fetch(`http://127.0.0.1:${port}/`, {
+      headers: { "x-forwarded-for": "5.6.7.8" },
+      signal: AbortSignal.timeout(5000),
+    });
+    equal(after.status, 403);
   } catch (err) {
     fail(err);
   } finally {

--- a/library/agent/Agent.test.ts
+++ b/library/agent/Agent.test.ts
@@ -1,4 +1,5 @@
 import * as FakeTimers from "@sinonjs/fake-timers";
+import { createServer } from "http";
 import { hostname, platform, release } from "os";
 import * as t from "tap";
 import { getSemverNodeVersion } from "../helpers/getNodeVersion";
@@ -1053,6 +1054,163 @@ t.test("it goes into monitoring mode after sending startup event", async () => {
 
   t.same(agent.shouldBlock(), false);
 });
+
+t.test(
+  "it stores realtimeUpdatesEnabled from the startup event response",
+  async () => {
+    const logger = new LoggerNoop();
+    const api = new ReportingAPIForTesting({
+      success: true,
+      endpoints: [],
+      configUpdatedAt: 0,
+      heartbeatIntervalInMS: 10 * 60 * 1000,
+      blockedUserIds: [],
+      allowedIPAddresses: [],
+      excludedUserIdsFromRateLimiting: [],
+      realtimeUpdatesEnabled: true,
+    });
+    const agent = createTestAgent({
+      token: new Token("123"),
+      suppressConsoleLog: false,
+      api,
+      logger,
+    });
+    t.same(agent.getConfig().isRealtimeUpdatesEnabled(), false);
+    agent.start([]);
+
+    // Wait for the event to be sent
+    await setTimeout(0);
+
+    t.same(agent.getConfig().isRealtimeUpdatesEnabled(), true);
+  }
+);
+
+t.test(
+  "it defaults realtimeUpdatesEnabled to false when absent from the response",
+  async () => {
+    const logger = new LoggerNoop();
+    const api = new ReportingAPIForTesting({
+      success: true,
+      endpoints: [],
+      configUpdatedAt: 0,
+      heartbeatIntervalInMS: 10 * 60 * 1000,
+      blockedUserIds: [],
+      allowedIPAddresses: [],
+      excludedUserIdsFromRateLimiting: [],
+    });
+    const agent = createTestAgent({
+      token: new Token("123"),
+      suppressConsoleLog: false,
+      api,
+      logger,
+    });
+    agent.start([]);
+
+    // Wait for the event to be sent
+    await setTimeout(0);
+
+    t.same(agent.getConfig().isRealtimeUpdatesEnabled(), false);
+  }
+);
+
+t.test(
+  "it does not connect to the SSE stream when realtimeUpdatesEnabled is false",
+  async () => {
+    let requestReceived = false;
+    const server = createServer((req, res) => {
+      requestReceived = true;
+      res.writeHead(200, { "Content-Type": "text/event-stream" });
+      res.end();
+    });
+    await new Promise<void>((resolve) => server.listen(0, resolve));
+    server.unref();
+    server.on("connection", (socket) => socket.unref());
+    const port = (server.address() as { port: number }).port;
+    process.env.AIKIDO_REALTIME_ENDPOINT = `http://localhost:${port}/`;
+
+    // isFeatureEnabled("sse") is forced true in unit tests unless we opt out,
+    // which would mask the effect of realtimeUpdatesEnabled being false
+    process.env.AIKIDO_UNIT_TESTS = "0";
+    delete process.env.AIKIDO_FEATURE_SSE;
+
+    try {
+      const logger = new LoggerNoop();
+      const api = new ReportingAPIForTesting({
+        success: true,
+        endpoints: [],
+        configUpdatedAt: 0,
+        heartbeatIntervalInMS: 10 * 60 * 1000,
+        blockedUserIds: [],
+        allowedIPAddresses: [],
+        excludedUserIdsFromRateLimiting: [],
+        realtimeUpdatesEnabled: false,
+      });
+      const agent = createTestAgent({
+        token: new Token("123"),
+        suppressConsoleLog: false,
+        api,
+        logger,
+      });
+      agent.start([]);
+
+      await setTimeout(200);
+
+      t.equal(requestReceived, false);
+    } finally {
+      delete process.env.AIKIDO_REALTIME_ENDPOINT;
+      process.env.AIKIDO_UNIT_TESTS = "1";
+    }
+  }
+);
+
+t.test(
+  "it connects to the SSE stream when realtimeUpdatesEnabled is true",
+  async () => {
+    let requestPath: string | undefined;
+    const server = createServer((req, res) => {
+      requestPath = req.url;
+      res.writeHead(200, {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        Connection: "keep-alive",
+      });
+      res.write(": ping\n\n");
+    });
+    await new Promise<void>((resolve) => server.listen(0, resolve));
+    server.unref();
+    server.on("connection", (socket) => socket.unref());
+    const port = (server.address() as { port: number }).port;
+    process.env.AIKIDO_REALTIME_ENDPOINT = `http://localhost:${port}/`;
+
+    try {
+      const logger = new LoggerNoop();
+      const api = new ReportingAPIForTesting({
+        success: true,
+        endpoints: [],
+        configUpdatedAt: 0,
+        heartbeatIntervalInMS: 10 * 60 * 1000,
+        blockedUserIds: [],
+        allowedIPAddresses: [],
+        excludedUserIdsFromRateLimiting: [],
+        realtimeUpdatesEnabled: true,
+      });
+      const agent = createTestAgent({
+        token: new Token("123"),
+        suppressConsoleLog: false,
+        api,
+        logger,
+      });
+      agent.start([]);
+
+      await setTimeout(200);
+
+      t.equal(requestPath, "/api/runtime/stream");
+    } finally {
+      delete process.env.AIKIDO_REALTIME_ENDPOINT;
+      server.close();
+    }
+  }
+);
 
 t.test("it sends middleware installed with heartbeat", async () => {
   const clock = FakeTimers.install();

--- a/library/agent/Agent.test.ts
+++ b/library/agent/Agent.test.ts
@@ -1067,7 +1067,7 @@ t.test(
       blockedUserIds: [],
       allowedIPAddresses: [],
       excludedUserIdsFromRateLimiting: [],
-      realtimeUpdatesEnabled: true,
+      enabledFeatures: ["runtime_updates"],
     });
     const agent = createTestAgent({
       token: new Token("123"),
@@ -1129,7 +1129,7 @@ t.test(
     process.env.AIKIDO_REALTIME_ENDPOINT = `http://localhost:${port}/`;
 
     // isFeatureEnabled("sse") is forced true in unit tests unless we opt out,
-    // which would mask the effect of realtimeUpdatesEnabled being false
+    // which would mask the effect of enabledFeatures not including runtime_updates
     process.env.AIKIDO_UNIT_TESTS = "0";
     delete process.env.AIKIDO_FEATURE_SSE;
 
@@ -1143,7 +1143,7 @@ t.test(
         blockedUserIds: [],
         allowedIPAddresses: [],
         excludedUserIdsFromRateLimiting: [],
-        realtimeUpdatesEnabled: false,
+        enabledFeatures: [],
       });
       const agent = createTestAgent({
         token: new Token("123"),
@@ -1192,7 +1192,7 @@ t.test(
         blockedUserIds: [],
         allowedIPAddresses: [],
         excludedUserIdsFromRateLimiting: [],
-        realtimeUpdatesEnabled: true,
+        enabledFeatures: ["runtime_updates"],
       });
       const agent = createTestAgent({
         token: new Token("123"),

--- a/library/agent/Agent.ts
+++ b/library/agent/Agent.ts
@@ -349,6 +349,12 @@ export class Agent {
           response.excludedUserIdsFromRateLimiting
         );
       }
+
+      if (typeof response.realtimeUpdatesEnabled === "boolean") {
+        this.serviceConfig.updateRealtimeUpdatesEnabled(
+          response.realtimeUpdatesEnabled
+        );
+      }
     }
   }
 
@@ -467,7 +473,10 @@ export class Agent {
 
     const lastUpdatedAt = this.serviceConfig.getLastUpdatedAt();
 
-    if (isFeatureEnabled("sse")) {
+    if (
+      isFeatureEnabled("sse") ||
+      this.serviceConfig.isRealtimeUpdatesEnabled()
+    ) {
       listenForConfigUpdates({
         token: this.token,
         logger: this.logger,

--- a/library/agent/Agent.ts
+++ b/library/agent/Agent.ts
@@ -350,10 +350,8 @@ export class Agent {
         );
       }
 
-      if (typeof response.realtimeUpdatesEnabled === "boolean") {
-        this.serviceConfig.updateRealtimeUpdatesEnabled(
-          response.realtimeUpdatesEnabled
-        );
+      if (Array.isArray(response.enabledFeatures)) {
+        this.serviceConfig.updateEnabledFeatures(response.enabledFeatures);
       }
     }
   }

--- a/library/agent/Config.ts
+++ b/library/agent/Config.ts
@@ -32,5 +32,5 @@ export type Config = {
   block?: boolean;
   blockNewOutgoingRequests?: boolean;
   domains?: Domain[];
-  realtimeUpdatesEnabled?: boolean;
+  enabledFeatures?: string[];
 };

--- a/library/agent/Config.ts
+++ b/library/agent/Config.ts
@@ -32,4 +32,5 @@ export type Config = {
   block?: boolean;
   blockNewOutgoingRequests?: boolean;
   domains?: Domain[];
+  realtimeUpdatesEnabled?: boolean;
 };

--- a/library/agent/ServiceConfig.test.ts
+++ b/library/agent/ServiceConfig.test.ts
@@ -24,10 +24,13 @@ t.test("realtime updates enabled defaults to false", async (t) => {
 t.test("it updates realtime updates enabled", async (t) => {
   const config = new ServiceConfig([], 0, [], [], [], []);
 
-  config.updateRealtimeUpdatesEnabled(true);
+  config.updateEnabledFeatures(["runtime_updates"]);
   t.same(config.isRealtimeUpdatesEnabled(), true);
 
-  config.updateRealtimeUpdatesEnabled(false);
+  config.updateEnabledFeatures([]);
+  t.same(config.isRealtimeUpdatesEnabled(), false);
+
+  config.updateEnabledFeatures(["some_other_feature"]);
   t.same(config.isRealtimeUpdatesEnabled(), false);
 });
 

--- a/library/agent/ServiceConfig.test.ts
+++ b/library/agent/ServiceConfig.test.ts
@@ -16,6 +16,21 @@ t.test("it returns false if empty rules", async () => {
   );
 });
 
+t.test("realtime updates enabled defaults to false", async (t) => {
+  const config = new ServiceConfig([], 0, [], [], [], []);
+  t.same(config.isRealtimeUpdatesEnabled(), false);
+});
+
+t.test("it updates realtime updates enabled", async (t) => {
+  const config = new ServiceConfig([], 0, [], [], [], []);
+
+  config.updateRealtimeUpdatesEnabled(true);
+  t.same(config.isRealtimeUpdatesEnabled(), true);
+
+  config.updateRealtimeUpdatesEnabled(false);
+  t.same(config.isRealtimeUpdatesEnabled(), false);
+});
+
 t.test("it works", async () => {
   const config = new ServiceConfig(
     [

--- a/library/agent/ServiceConfig.ts
+++ b/library/agent/ServiceConfig.ts
@@ -35,7 +35,7 @@ export class ServiceConfig {
 
   private excludedUserIdsFromRateLimiting = new Set<string>();
 
-  private realtimeUpdatesEnabled = false;
+  private enabledFeatures = new Set<string>();
 
   constructor(
     endpoints: EndpointConfig[],
@@ -322,11 +322,11 @@ export class ServiceConfig {
     return this.excludedUserIdsFromRateLimiting.has(userId);
   }
 
-  updateRealtimeUpdatesEnabled(enabled: boolean) {
-    this.realtimeUpdatesEnabled = enabled;
+  updateEnabledFeatures(features: string[]) {
+    this.enabledFeatures = new Set(features);
   }
 
   isRealtimeUpdatesEnabled(): boolean {
-    return this.realtimeUpdatesEnabled;
+    return this.enabledFeatures.has("runtime_updates");
   }
 }

--- a/library/agent/ServiceConfig.ts
+++ b/library/agent/ServiceConfig.ts
@@ -35,6 +35,8 @@ export class ServiceConfig {
 
   private excludedUserIdsFromRateLimiting = new Set<string>();
 
+  private realtimeUpdatesEnabled = false;
+
   constructor(
     endpoints: EndpointConfig[],
     private lastUpdatedAt: number,
@@ -318,5 +320,13 @@ export class ServiceConfig {
 
   isUserExcludedFromRateLimiting(userId: string): boolean {
     return this.excludedUserIdsFromRateLimiting.has(userId);
+  }
+
+  updateRealtimeUpdatesEnabled(enabled: boolean) {
+    this.realtimeUpdatesEnabled = enabled;
+  }
+
+  isRealtimeUpdatesEnabled(): boolean {
+    return this.realtimeUpdatesEnabled;
   }
 }


### PR DESCRIPTION
This change exposes the new `realtimeUpdatesEnabled` flag from the runtime config response as `ServiceConfig.isRealtimeUpdatesEnabled()`, and starts listening for SSE config updates when either the existing `isFeatureEnabled("sse")` local flag or `ServiceConfig.isRealtimeUpdatesEnabled()` is true.