### PR TITLE
Check that hono method exists before wrapping

### DIFF
--- a/library/sources/Hono.ts
+++ b/library/sources/Hono.ts
@@ -46,10 +46,12 @@ export class Hono implements Wrapper {
 
         wrapNewInstance(newExports, "Hono", pkgInfo, (instance) => {
           METHODS.forEach((method) => {
-            wrapExport(instance, method, pkgInfo, {
-              kind: undefined,
-              modifyArgs: this.wrapArgs,
-            });
+            if (typeof instance[method] === "function") {
+              wrapExport(instance, method, pkgInfo, {
+                kind: undefined,
+                modifyArgs: this.wrapArgs,
+              });
+            }
           });
         });
 


### PR DESCRIPTION
Prevents this warning from being logged in debug mode which older Hono versions: AIKIDO: Failed to wrap method query in module hono: no original function query to wrap