### PR TITLE
Forward missing argument for vm.Script

### DIFF
--- a/library/sinks/NodeVm.test.ts
+++ b/library/sinks/NodeVm.test.ts
@@ -29,6 +29,23 @@ t.test("it works", async (t) => {
   agent.start([new NodeVm()]);
 
   const vm = require("vm");
+  const Script = vm.Script as typeof import("node:vm").Script;
+
+  class CustomScript extends Script {
+    runInThisContext() {
+      return "custom-result";
+    }
+  }
+
+  const assertSubclassIsPreserved = (script: CustomScript) => {
+    t.ok(script instanceof CustomScript);
+    t.equal(script.runInThisContext(), "custom-result");
+  };
+
+  assertSubclassIsPreserved(new CustomScript("1 + 1"));
+  assertSubclassIsPreserved(
+    Reflect.construct(vm.Script, ["1 + 1"], CustomScript)
+  );
 
   {
     // @ts-expect-error Not typed
@@ -49,6 +66,8 @@ t.test("it works", async (t) => {
   }
 
   runWithContext(safeContext, () => {
+    assertSubclassIsPreserved(new CustomScript("1 + 1"));
+
     t.doesNotThrow(() => {
       new vm.Script(`console.log('${safeContext.body.code}');`);
     });

--- a/library/sinks/NodeVm.ts
+++ b/library/sinks/NodeVm.ts
@@ -25,12 +25,12 @@ export class NodeVm implements Wrapper {
     });
   }
 
-  private onConstruct(target: any, args: unknown[]) {
+  private onConstruct(target: any, args: unknown[], newTarget: Function) {
     const agent = getInstance();
     const context = getContext();
 
     if (!agent || !context) {
-      return new target(...args);
+      return Reflect.construct(target, args, newTarget);
     }
 
     inspectArgs(
@@ -46,14 +46,15 @@ export class NodeVm implements Wrapper {
       "eval_op"
     );
 
-    return new target(...args);
+    return Reflect.construct(target, args, newTarget);
   }
 
   wrap(hooks: Hooks): void {
     hooks.addBuiltinModule("vm").onRequire((exports, pkgInfo) => {
       // We can't use our helper wrapNewInstance because it can not inspect constructor args
       exports.Script = new Proxy(exports.Script, {
-        construct: (target, args) => this.onConstruct(target, args),
+        construct: (target, args, newTarget) =>
+          this.onConstruct(target, args, newTarget),
       });
 
       const functionsToWrap = [


### PR DESCRIPTION
Important when a class extends vm.Script